### PR TITLE
feat: add QR code generation for active tab in popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A Chrome extension that automatically audits and closes browser tabs to free mem
 - **Activity Tracking** - Robust tab activity detection that resets the idle timer when you interact with tabs
 - **Notifications** - Get notified when tabs are automatically closed
 - **Manual Cleanup** - Trigger cleanup on demand from the popup
+- **QR Code Generation** - Generate QR codes for the current page to easily share or open on other devices
 
 ## Installation
 
@@ -173,14 +174,19 @@ npm run test:coverage
 
 ```
 src/
+├── adapters/         # External system adapters
 ├── background/       # Service worker (main logic)
 │   └── index.ts      # Tab cleanup rules, activity tracking
-├── popup/            # Browser action popup UI
+├── core/             # Business logic layer
+├── icons/            # Extension icons
 ├── options/          # Extension options page
+├── platform/         # Platform-specific code
+├── popup/            # Browser action popup UI
 ├── shared/           # Shared code
 │   ├── settings.ts   # Settings interface and storage
 │   ├── types.ts      # TypeScript interfaces
 │   ├── constants.ts  # Shared constants
+│   ├── domain.ts     # Domain parsing utilities
 │   └── utils.ts      # Utility functions
 └── manifest.json     # Chrome extension manifest (V3)
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,19 @@
 {
   "name": "tab-audit",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tab-audit",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "license": "MIT",
+      "dependencies": {
+        "qrcode": "^1.5.4"
+      },
       "devDependencies": {
         "@types/chrome": "^0.1.32",
+        "@types/qrcode": "^1.5.6",
         "@typescript-eslint/eslint-plugin": "^6.9.1",
         "@typescript-eslint/parser": "^6.9.1",
         "@vitest/browser": "^4.0.17",
@@ -1740,6 +1744,16 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/semver": {
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
@@ -2477,7 +2491,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2487,7 +2500,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2629,6 +2641,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001763",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001763.tgz",
@@ -2687,6 +2708,17 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
     "node_modules/clone-deep": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -2706,7 +2738,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2719,7 +2750,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -2834,6 +2864,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2850,6 +2889,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -2883,6 +2928,12 @@
       "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.18.4",
@@ -3390,6 +3441,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -3681,6 +3741,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -4185,7 +4254,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4208,7 +4276,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4435,6 +4502,32 @@
         "node": ">=6"
       }
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -4479,6 +4572,15 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -4488,6 +4590,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -4741,6 +4849,12 @@
         "randombytes": "^2.1.0"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
+    },
     "node_modules/shallow-clone": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
@@ -4909,11 +5023,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -5662,6 +5789,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -5696,6 +5829,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -5723,6 +5870,99 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@types/chrome": "^0.1.32",
+    "@types/qrcode": "^1.5.6",
     "@typescript-eslint/eslint-plugin": "^6.9.1",
     "@typescript-eslint/parser": "^6.9.1",
     "@vitest/browser": "^4.0.17",
@@ -51,5 +52,8 @@
   "repository": {
     "type": "git",
     "url": ""
+  },
+  "dependencies": {
+    "qrcode": "^1.5.4"
   }
 }

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -199,3 +199,60 @@ button {
 [data-theme='dark'] .btn-icon:hover {
   background-color: var(--primary-hover);
 }
+
+.qr-section {
+  background-color: var(--card-bg);
+  border-radius: 12px;
+  padding: 16px;
+  border: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  transition:
+    background-color 0.3s,
+    border-color 0.3s;
+}
+
+.qr-header {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.qr-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.qr-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 8px;
+  background: white;
+  border-radius: 8px;
+}
+
+#qr-canvas {
+  max-width: 150px;
+  height: auto;
+}
+
+.qr-url {
+  font-size: 11px;
+  color: var(--text-muted);
+  text-align: center;
+  word-break: break-all;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-theme='dark'] .qr-container {
+  background: #ffffff;
+}

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -45,6 +45,16 @@
           </svg>
         </button>
       </div>
+
+      <div class="qr-section">
+        <div class="qr-header">
+          <span class="qr-label">Current Page QR</span>
+        </div>
+        <div id="qr-container" class="qr-container">
+          <canvas id="qr-canvas"></canvas>
+        </div>
+        <div id="qr-url" class="qr-url"></div>
+      </div>
     </div>
     <script src="index.js"></script>
   </body>

--- a/src/popup/popup.test.ts
+++ b/src/popup/popup.test.ts
@@ -11,6 +11,7 @@ import {
   updateButton,
   handleToggle,
   initPopup,
+  generateQRCode,
   PopupElements,
 } from './popup';
 
@@ -43,6 +44,35 @@ vi.stubGlobal('document', {
   documentElement: mockDocumentElement,
   getElementById: mockGetElementById,
   addEventListener: mockAddEventListener,
+  createElement: vi.fn((tag) => ({
+    tagName: tag.toUpperCase(),
+    textContent: '',
+    className: '',
+    setAttribute: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    appendChild: vi.fn(),
+    querySelector: vi.fn(),
+    querySelectorAll: vi.fn(() => []),
+    style: {},
+    clientWidth: 100,
+    clientHeight: 100,
+    getContext: vi.fn(() => ({
+      fillRect: vi.fn(),
+      fillText: vi.fn(),
+      beginPath: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      stroke: vi.fn(),
+      rect: vi.fn(),
+      clearRect: vi.fn(),
+      createImageData: vi.fn(() => ({
+        data: new Uint8ClampedArray(100),
+      })),
+      putImageData: vi.fn(),
+      scale: vi.fn(),
+    })),
+  })),
 });
 
 // Mock chrome.runtime.openOptionsPage
@@ -520,5 +550,159 @@ describe('initPopup', () => {
     expect(mockDocumentElement.setAttribute).toHaveBeenCalledWith('data-theme', 'dark');
     // @ts-expect-error - chrome is mocked
     expect(chrome.storage.local.get).toHaveBeenCalled();
+  });
+});
+
+describe('generateQRCode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return early when qrCanvas is missing', async () => {
+    const elements = {
+      tabCount: document.createElement('div'),
+      cleanedCount: document.createElement('div'),
+      topDomain: document.createElement('div'),
+      toggleButton: document.createElement('button'),
+      settingsButton: null,
+      qrCanvas: null as unknown as HTMLCanvasElement,
+      qrUrl: document.createElement('div'),
+    };
+
+    await generateQRCode(elements);
+    // @ts-expect-error - chrome is mocked
+    expect(chrome.tabs.query).not.toHaveBeenCalled();
+  });
+
+  it('should return early when qrUrl is missing', async () => {
+    const elements = {
+      tabCount: document.createElement('div'),
+      cleanedCount: document.createElement('div'),
+      topDomain: document.createElement('div'),
+      toggleButton: document.createElement('button'),
+      settingsButton: null,
+      qrCanvas: document.createElement('canvas'),
+      qrUrl: null as unknown as HTMLElement,
+    };
+
+    await generateQRCode(elements);
+    // @ts-expect-error - chrome is mocked
+    expect(chrome.tabs.query).not.toHaveBeenCalled();
+  });
+
+  it('should show message for chrome:// URLs', async () => {
+    const qrUrl = document.createElement('div');
+    const elements = {
+      tabCount: document.createElement('div'),
+      cleanedCount: document.createElement('div'),
+      topDomain: document.createElement('div'),
+      toggleButton: document.createElement('button'),
+      settingsButton: null,
+      qrCanvas: document.createElement('canvas'),
+      qrUrl,
+    };
+
+    // @ts-expect-error - chrome is mocked
+    chrome.tabs.query.mockResolvedValue([{ url: 'chrome://settings' }]);
+
+    await generateQRCode(elements);
+    expect(qrUrl.textContent).toBe('Cannot generate QR for this page');
+  });
+
+  it('should show message for chrome-extension:// URLs', async () => {
+    const qrUrl = document.createElement('div');
+    const elements = {
+      tabCount: document.createElement('div'),
+      cleanedCount: document.createElement('div'),
+      topDomain: document.createElement('div'),
+      toggleButton: document.createElement('button'),
+      settingsButton: null,
+      qrCanvas: document.createElement('canvas'),
+      qrUrl,
+    };
+
+    // @ts-expect-error - chrome is mocked
+    chrome.tabs.query.mockResolvedValue([{ url: 'chrome-extension://abcdefghijk/lmnop.html' }]);
+
+    await generateQRCode(elements);
+    expect(qrUrl.textContent).toBe('Cannot generate QR for this page');
+  });
+
+  it('should generate QR code and show URL for valid tab', async () => {
+    const qrCanvas = document.createElement('canvas');
+    const qrUrl = document.createElement('div');
+    const elements = {
+      tabCount: document.createElement('div'),
+      cleanedCount: document.createElement('div'),
+      topDomain: document.createElement('div'),
+      toggleButton: document.createElement('button'),
+      settingsButton: null,
+      qrCanvas,
+      qrUrl,
+    };
+
+    // @ts-expect-error - chrome is mocked
+    chrome.tabs.query.mockResolvedValue([{ url: 'https://example.com/page' }]);
+
+    await generateQRCode(elements);
+    expect(qrUrl.textContent).toBe('https://example.com/page');
+  });
+
+  it('should truncate long URLs', async () => {
+    const qrUrl = document.createElement('div');
+    const elements = {
+      tabCount: document.createElement('div'),
+      cleanedCount: document.createElement('div'),
+      topDomain: document.createElement('div'),
+      toggleButton: document.createElement('button'),
+      settingsButton: null,
+      qrCanvas: document.createElement('canvas'),
+      qrUrl,
+    };
+
+    const longUrl = 'https://example.com/very/long/path/with/many/segments/and/query/parameters?foo=bar&baz=qux';
+    // @ts-expect-error - chrome is mocked
+    chrome.tabs.query.mockResolvedValue([{ url: longUrl }]);
+
+    await generateQRCode(elements);
+    expect(qrUrl.textContent).toBe('https://example.com/very/long/path/with/...');
+  });
+
+  it('should handle missing tab gracefully', async () => {
+    const qrUrl = document.createElement('div');
+    const elements = {
+      tabCount: document.createElement('div'),
+      cleanedCount: document.createElement('div'),
+      topDomain: document.createElement('div'),
+      toggleButton: document.createElement('button'),
+      settingsButton: null,
+      qrCanvas: document.createElement('canvas'),
+      qrUrl,
+    };
+
+    // @ts-expect-error - chrome is mocked
+    chrome.tabs.query.mockResolvedValue([]);
+
+    await generateQRCode(elements);
+    expect(qrUrl.textContent).toBe('Cannot generate QR for this page');
+  });
+
+  it('should handle tabs without URL gracefully', async () => {
+    const qrUrl = document.createElement('div');
+    const elements = {
+      tabCount: document.createElement('div'),
+      cleanedCount: document.createElement('div'),
+      topDomain: document.createElement('div'),
+      toggleButton: document.createElement('button'),
+      settingsButton: null,
+      qrCanvas: document.createElement('canvas'),
+      qrUrl,
+    };
+
+    // @ts-expect-error - chrome is mocked
+    chrome.tabs.query.mockResolvedValue([{ url: undefined }]);
+
+    await generateQRCode(elements);
+    expect(qrUrl.textContent).toBe('Cannot generate QR for this page');
   });
 });

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -1,4 +1,5 @@
 import { getSettings, saveSettings } from '../shared/settings';
+import QRCode from 'qrcode';
 
 /**
  * Applies the theme to the document.
@@ -74,6 +75,8 @@ export interface PopupElements {
   topDomain: HTMLElement;
   toggleButton: HTMLButtonElement;
   settingsButton: HTMLButtonElement | null;
+  qrCanvas: HTMLCanvasElement;
+  qrUrl: HTMLElement;
 }
 
 /**
@@ -86,6 +89,8 @@ export function getPopupElements(): PopupElements | null {
   const topDomain = document.getElementById('top-domain') as HTMLElement;
   const toggleButton = document.getElementById('toggle-clean') as HTMLButtonElement;
   const settingsButton = document.getElementById('open-settings') as HTMLButtonElement | null;
+  const qrCanvas = document.getElementById('qr-canvas') as HTMLCanvasElement;
+  const qrUrl = document.getElementById('qr-url') as HTMLElement;
 
   if (!tabCount || !cleanedCount || !topDomain || !toggleButton) {
     return null;
@@ -97,6 +102,8 @@ export function getPopupElements(): PopupElements | null {
     topDomain,
     toggleButton,
     settingsButton,
+    qrCanvas,
+    qrUrl,
   };
 }
 
@@ -137,6 +144,40 @@ export function updateButton(elements: PopupElements, enabled: boolean): void {
 }
 
 /**
+ * Generates and displays QR code for the active tab's URL.
+ * @param elements - Popup elements including QR canvas and URL container
+ */
+export async function generateQRCode(elements: PopupElements): Promise<void> {
+  if (!elements.qrCanvas || !elements.qrUrl) {
+    return;
+  }
+
+  try {
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+
+    if (!tab || !tab.url || tab.url.startsWith('chrome://') || tab.url.startsWith('chrome-extension://')) {
+      elements.qrUrl.textContent = 'Cannot generate QR for this page';
+      return;
+    }
+
+    await QRCode.toCanvas(elements.qrCanvas, tab.url, {
+      width: 150,
+      margin: 1,
+      color: {
+        dark: '#000000',
+        light: '#ffffff',
+      },
+    });
+
+    const displayUrl = tab.url.length > 40 ? tab.url.substring(0, 40) + '...' : tab.url;
+    elements.qrUrl.textContent = displayUrl;
+  } catch (error) {
+    console.error('Failed to generate QR code:', error);
+    elements.qrUrl.textContent = 'Failed to generate QR code';
+  }
+}
+
+/**
  * Handles toggle button click.
  * @param elements - Popup elements
  */
@@ -170,6 +211,9 @@ export async function initPopup(): Promise<void> {
   // Update tab count and stats on load
   updateTabCount(elements);
   await updateStats(elements);
+
+  // Generate QR code for active tab
+  await generateQRCode(elements);
 
   // Toggle button click
   elements.toggleButton.addEventListener('click', async () => {


### PR DESCRIPTION
## Summary

Add QR code generation feature to the popup that displays a QR code for the currently visited page URL.

## Changes

- Add `qrcode` library for generating QR codes
- Add QR section to popup UI showing current page URL as QR code
- Automatically generate QR when popup opens
- Skip chrome:// and chrome-extension:// URLs (cannot generate QR for these)

## Testing

- All 233 tests pass
- Lint clean
- Build successful

## Usage

Open the extension popup → QR code automatically appears for the current tab's URL. Scan with phone to open the page on another device.