### PR TITLE
feat: automate version updates in package.json and manifest.json on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,14 @@ jobs:
       with:
         node-version: '20.x'
         cache: 'npm'
-        
+
+    - name: Update version
+      run: |
+        VERSION=${GITHUB_REF#refs/tags/v}
+        echo "Updating version to $VERSION"
+        npm version $VERSION --no-git-tag-version --allow-same-version
+        jq --arg v "$VERSION" '.version = $v' src/manifest.json > src/manifest.tmp.json && mv src/manifest.tmp.json src/manifest.json
+
     - name: Install dependencies
       run: npm ci
       
@@ -33,6 +40,14 @@ jobs:
     - name: Package extension
       run: npm run package
       
+    - name: Commit version update
+      run: |
+        git config --local user.email "github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
+        git add package.json src/manifest.json
+        git commit -m "chore: bump version to ${{ github.ref_name }}"
+        git push
+
     - name: Create Release
       uses: softprops/action-gh-release@v2
       with:


### PR DESCRIPTION
## Summary
- Automates version updates in `package.json` and `src/manifest.json` when a new tag is pushed
- Extracts version from git tag (e.g., `v1.2.0` → `1.2.0`)
- Updates both JSON files with the new version
- Commits version changes back to main branch

## How it works
```bash
git tag v1.2.0
git push origin v1.2.0
```

The release workflow now:
1. Extracts version from the tag
2. Updates `package.json` via `npm version`
3. Updates `src/manifest.json` via `jq`
4. Commits the changes back to main
5. Creates GitHub Release

This eliminates manual version editing when releasing.