### PR TITLE
refactor: consolidate duplicated getDomain() and applyTheme()

### DIFF
--- a/src/options/options.test.ts
+++ b/src/options/options.test.ts
@@ -3,8 +3,8 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // Mock Chrome APIs and DOM before importing the module
 import './__mocks__/chrome';
+import { applyTheme } from '../shared/theme';
 import {
-  applyTheme,
   isValidSettings,
   getFormElements,
   loadSettingsToForm,

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -1,16 +1,5 @@
 import { getSettings, saveSettings, DEFAULT_SETTINGS, Settings } from '../shared/settings';
-
-/**
- * Applies the theme to the document.
- * @param theme - 'light', 'dark', or 'system'
- */
-export function applyTheme(theme: 'light' | 'dark' | 'system'): void {
-  let resolvedTheme = theme;
-  if (theme === 'system') {
-    resolvedTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-  }
-  document.documentElement.setAttribute('data-theme', resolvedTheme);
-}
+import { applyTheme } from '../shared/theme';
 
 /**
  * Validates imported settings.

--- a/src/popup/popup.test.ts
+++ b/src/popup/popup.test.ts
@@ -1,9 +1,9 @@
 // @ts-nocheck
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import './__mocks__/chrome';
+import { applyTheme } from '../shared/theme';
+import { getDomain } from '../shared/domain';
 import {
-  applyTheme,
-  getDomain,
   getTabStats,
   getPopupElements,
   updateTabCount,

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -1,30 +1,7 @@
 import { getSettings, saveSettings } from '../shared/settings';
+import { getDomain } from '../shared/domain';
+import { applyTheme } from '../shared/theme';
 import QRCode from 'qrcode';
-
-/**
- * Applies the theme to the document.
- * @param theme - 'light', 'dark', or 'system'
- */
-export function applyTheme(theme: 'light' | 'dark' | 'system'): void {
-  let resolvedTheme = theme;
-  if (theme === 'system') {
-    resolvedTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-  }
-  document.documentElement.setAttribute('data-theme', resolvedTheme);
-}
-
-/**
- * Gets domain from URL.
- * @param url - The URL to extract domain from
- * @returns The domain name or empty string
- */
-export function getDomain(url: string): string {
-  try {
-    return new URL(url).hostname;
-  } catch {
-    return '';
-  }
-}
 
 /**
  * Gets statistics about current tabs.

--- a/src/shared/theme.ts
+++ b/src/shared/theme.ts
@@ -1,0 +1,11 @@
+/**
+ * Applies the theme to the document.
+ * @param theme - 'light', 'dark', or 'system'
+ */
+export function applyTheme(theme: 'light' | 'dark' | 'system'): void {
+  let resolvedTheme = theme;
+  if (theme === 'system') {
+    resolvedTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  document.documentElement.setAttribute('data-theme', resolvedTheme);
+}


### PR DESCRIPTION
Move applyTheme() from popup.ts and options.ts to new shared/theme.ts. Replace popup.ts local getDomain() with import from shared/domain.ts.

Closes #12