### PR TITLE
fix: popup cleaned today count always shows 0

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -156,6 +156,18 @@ export async function applyCleanupRules() {
       await chrome.tabs.remove(result.tabIdsToClose);
       console.log('Closed tabs:', result.tabIdsToClose);
 
+      // Track the number of tabs cleaned today (resets each day)
+      const today = new Date().toISOString().split('T')[0];
+      const stored = (await chrome.storage.local.get(['tabsCleanedToday', 'tabsCleanedDate'])) as {
+        tabsCleanedToday?: number;
+        tabsCleanedDate?: string;
+      };
+      const prevCount = stored.tabsCleanedDate === today ? (stored.tabsCleanedToday ?? 0) : 0;
+      await chrome.storage.local.set({
+        tabsCleanedToday: prevCount + result.tabIdsToClose.length,
+        tabsCleanedDate: today,
+      });
+
       if (notificationsEnabled) {
         chrome.notifications.create(
           {


### PR DESCRIPTION
Closes #20

## Problem

The popup reads `chrome.storage.local['tabsCleanedToday']` to display the number of tabs cleaned today, but `applyCleanupRules()` was closing tabs without ever incrementing this counter. The popup always showed `0` (or `-`).

## Fix

After `applyCleanupRules()` closes tabs, it now:
1. Reads the current day's count and date from `chrome.storage.local`
2. Resets to `0` if the day has rolled over (new date)
3. Increments by the number of tabs just closed
4. Writes both `tabsCleanedToday` and `tabsCleanedDate` back to storage

## Testing

All 273 existing tests pass (0 regressions). The change is additive — existing `applyCleanupRules` tests continue to verify tab closing behavior, and the `chrome.storage.local` mocks handle the new calls transparently.