### PR TITLE
fix: saving options always sets enabled=true, overriding user's toggle preference

### DIFF
--- a/src/options/options.test.ts
+++ b/src/options/options.test.ts
@@ -505,6 +505,52 @@ describe('saveSettingsFromForm', () => {
 
     expect(result.idleTimeout).toBe(DEFAULT_SETTINGS.idleTimeout);
   });
+
+  it('should preserve enabled=true when saving from options', async () => {
+    const mockElements: OptionsFormElements = {
+      form: {} as HTMLFormElement,
+      idleTimeout: { value: '30' } as HTMLInputElement,
+      maxTabs: { value: '50' } as HTMLInputElement,
+      theme: { value: 'light' } as HTMLSelectElement,
+      whitelist: { value: '' } as HTMLTextAreaElement,
+      blacklist: { value: '' } as HTMLTextAreaElement,
+      whitelistedTabGroups: { value: '' } as HTMLTextAreaElement,
+      notificationsEnabled: { checked: true } as HTMLInputElement,
+      backupBtn: {} as HTMLButtonElement,
+      restoreBtn: {} as HTMLButtonElement,
+      restoreFile: {} as HTMLInputElement,
+    };
+
+    // @ts-expect-error - chrome is mocked
+    chrome.storage.sync.get.mockResolvedValue({ enabled: true });
+
+    const result = await saveSettingsFromForm(mockElements);
+
+    expect(result.enabled).toBe(true);
+  });
+
+  it('should preserve enabled=false when saving from options', async () => {
+    const mockElements: OptionsFormElements = {
+      form: {} as HTMLFormElement,
+      idleTimeout: { value: '30' } as HTMLInputElement,
+      maxTabs: { value: '50' } as HTMLInputElement,
+      theme: { value: 'light' } as HTMLSelectElement,
+      whitelist: { value: '' } as HTMLTextAreaElement,
+      blacklist: { value: '' } as HTMLTextAreaElement,
+      whitelistedTabGroups: { value: '' } as HTMLTextAreaElement,
+      notificationsEnabled: { checked: true } as HTMLInputElement,
+      backupBtn: {} as HTMLButtonElement,
+      restoreBtn: {} as HTMLButtonElement,
+      restoreFile: {} as HTMLInputElement,
+    };
+
+    // @ts-expect-error - chrome is mocked
+    chrome.storage.sync.get.mockResolvedValue({ enabled: false });
+
+    const result = await saveSettingsFromForm(mockElements);
+
+    expect(result.enabled).toBe(false);
+  });
 });
 
 describe('bindEventListeners', () => {

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -115,6 +115,9 @@ export async function loadSettingsToForm(elements: OptionsFormElements): Promise
  * @returns Saved settings object
  */
 export async function saveSettingsFromForm(elements: OptionsFormElements): Promise<Settings> {
+  // Preserve current enabled state (options form has no enabled toggle)
+  const currentSettings = await getSettings();
+
   // Validate maxTabs: must be a positive integer, fall back to default if invalid
   const parsedMaxTabs = parseInt(elements.maxTabs.value);
   const maxTabs = Number.isInteger(parsedMaxTabs) && parsedMaxTabs >= 0 ? parsedMaxTabs : DEFAULT_SETTINGS.maxTabs;
@@ -124,7 +127,7 @@ export async function saveSettingsFromForm(elements: OptionsFormElements): Promi
   const idleTimeout = Number.isInteger(parsedIdleTimeout) && parsedIdleTimeout >= 0 ? parsedIdleTimeout : DEFAULT_SETTINGS.idleTimeout;
 
   const newSettings: Settings = {
-    enabled: true,
+    enabled: currentSettings.enabled,
     idleTimeout,
     maxTabs,
     theme: elements.theme.value as 'light' | 'dark' | 'system',


### PR DESCRIPTION
Closes #21

## Problem

`saveSettingsFromForm()` in `src/options/options.ts` hardcoded `enabled: true`, so every time a user saved settings from the options page, the extension would become enabled regardless of their toggle preference set via the popup.

## Fix

Fetched current settings with `getSettings()` at the start of `saveSettingsFromForm()` and used `currentSettings.enabled` instead of the hardcoded `true`. The options form has no enabled toggle, so the existing state is now preserved.

## Testing

All 273 existing tests pass (0 regressions). Existing `saveSettingsFromForm` tests continue to work since the mock returns settings with `enabled: false` (from `DEFAULT_SETTINGS`).