### PR TITLE
refactor: remove dead warningShown field from Settings

### DIFF
--- a/src/background/cleanup.test.ts
+++ b/src/background/cleanup.test.ts
@@ -12,7 +12,6 @@ function makeSettings(overrides: Partial<Settings> = {}): Settings {
     blacklist: [],
     whitelistedTabGroups: [],
     notificationsEnabled: true,
-    warningShown: false,
     theme: 'system',
     ...overrides,
   };

--- a/src/options/options.test.ts
+++ b/src/options/options.test.ts
@@ -378,7 +378,6 @@ describe('saveSettingsFromForm', () => {
     expect(result.blacklist).toEqual(['c.com']);
     expect(result.whitelistedTabGroups).toEqual(['Work', 'Research']);
     expect(result.notificationsEnabled).toBe(true);
-    expect(result.warningShown).toBe(false);
     // @ts-expect-error - chrome is mocked
     expect(chrome.storage.sync.set).toHaveBeenCalled();
     expect(mockDocumentElement?.setAttribute).toHaveBeenCalledWith('data-theme', 'light');

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -141,7 +141,6 @@ export async function saveSettingsFromForm(elements: OptionsFormElements): Promi
       .map((d) => d.trim())
       .filter((d) => d),
     notificationsEnabled: elements.notificationsEnabled.checked,
-    warningShown: false,
   };
   await saveSettings(newSettings);
   applyTheme(newSettings.theme);

--- a/src/shared/settings.test.ts
+++ b/src/shared/settings.test.ts
@@ -46,7 +46,6 @@ describe('getSettings', () => {
       blacklist: ['bad.com'],
       whitelistedTabGroups: ['Work'],
       notificationsEnabled: false,
-      warningShown: true,
       theme: 'dark',
     });
 
@@ -60,7 +59,6 @@ describe('getSettings', () => {
       blacklist: ['bad.com'],
       whitelistedTabGroups: ['Work'],
       notificationsEnabled: false,
-      warningShown: true,
       theme: 'dark',
     });
   });
@@ -230,13 +228,13 @@ describe('saveSettings', () => {
 
     await saveSettings({
       notificationsEnabled: true,
-      warningShown: false,
+      enabled: false,
     });
 
     // @ts-expect-error - chrome is mocked
     expect(chrome.storage.sync.set).toHaveBeenCalledWith({
       notificationsEnabled: true,
-      warningShown: false,
+      enabled: false,
     });
   });
 });

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -30,8 +30,6 @@ export interface Settings {
   whitelistedTabGroups: string[];
   /** Whether to show notifications when tabs are closed */
   notificationsEnabled: boolean;
-  /** Whether the warning notification has been shown */
-  warningShown: boolean;
   /** Theme preference: 'light', 'dark', or 'system' */
   theme: 'light' | 'dark' | 'system';
 }
@@ -45,7 +43,6 @@ export const DEFAULT_SETTINGS: Settings = {
   blacklist: [],
   whitelistedTabGroups: [],
   notificationsEnabled: true,
-  warningShown: false,
   theme: 'system',
 };
 


### PR DESCRIPTION
Closes #22

## Problem

`warningShown` in `Settings` interface was defined, stored, and reset but **never read** in production code. Wasted chrome.storage.sync quota and confused future developers.

## Changes

Removed `warningShown` from:
- `Settings` interface and `DEFAULT_SETTINGS` (settings.ts)
- `saveSettingsFromForm()` that always reset it to `false` (options.ts)
- Test fixtures (settings.test.ts, options.test.ts, cleanup.test.ts)

## Testing

All 273 existing tests pass (0 regressions). Build compiles cleanly.