### PR TITLE
fix: handle unhandled promise rejections in async event listeners

### DIFF
--- a/src/__test-utils__/chrome-mock.ts
+++ b/src/__test-utils__/chrome-mock.ts
@@ -1,0 +1,66 @@
+import type { MockInstance } from 'vitest';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type MockFunction = MockInstance<any>;
+
+interface MockAlarms {
+  create: MockFunction;
+  onAlarm: { addListener: MockFunction };
+}
+
+interface MockCommands {
+  onCommand: { addListener: MockFunction };
+}
+
+interface MockRuntime {
+  onInstalled?: { addListener: MockFunction };
+  onStartup?: { addListener: MockFunction };
+  onMessage?: { addListener: MockFunction };
+  sendMessage: MockFunction;
+  openOptionsPage?: MockFunction;
+  getURL?: (path: string) => string;
+  lastError?: { message: string };
+}
+
+interface MockTabGroups {
+  query: MockFunction;
+}
+
+interface MockTabs {
+  query: MockFunction;
+  remove: MockFunction;
+  onActivated?: { addListener: MockFunction };
+  onUpdated?: { addListener: MockFunction };
+  onCreated?: { addListener: MockFunction };
+  onRemoved?: { addListener: MockFunction };
+}
+
+interface MockAction {
+  setIcon: MockFunction;
+}
+
+interface MockNotifications {
+  create: MockFunction;
+}
+
+interface MockStorageArea {
+  get: MockFunction;
+  set: MockFunction;
+}
+
+interface MockStorage {
+  local: MockStorageArea;
+  sync: MockStorageArea;
+  onChanged?: { addListener: MockFunction };
+}
+
+export interface MockChrome {
+  alarms?: MockAlarms;
+  commands?: MockCommands;
+  runtime: MockRuntime;
+  tabGroups?: MockTabGroups;
+  tabs: MockTabs;
+  action?: MockAction;
+  notifications?: MockNotifications;
+  storage: MockStorage;
+}

--- a/src/background/index.test.ts
+++ b/src/background/index.test.ts
@@ -24,6 +24,16 @@ import { applyCleanupRules } from './index';
 // @ts-expect-error - chrome is mocked
 const messageListener = chrome.runtime.onMessage.addListener.mock.calls[0][0];
 
+// Capture other event listeners registered during module import
+// @ts-expect-error - chrome is mocked
+const createdListener = chrome.tabs.onCreated.addListener.mock.calls[0][0];
+// @ts-expect-error - chrome is mocked
+const removedListener = chrome.tabs.onRemoved.addListener.mock.calls[0][0];
+// @ts-expect-error - chrome is mocked
+const storageChangedListener = chrome.storage.onChanged.addListener.mock.calls[0][0];
+// @ts-expect-error - chrome is mocked
+const commandListener = chrome.commands.onCommand.addListener.mock.calls[0][0];
+
 describe('updateTabActivity', () => {
   beforeEach(() => {
     resetTabActivityMap();
@@ -1660,8 +1670,108 @@ describe('chrome.runtime.onMessage runCleanup', () => {
   it('should return undefined for unknown actions', () => {
     const sendResponse = vi.fn();
     const result = messageListener({ action: 'unknown' }, {}, sendResponse);
-
     expect(result).toBeUndefined();
     expect(sendResponse).not.toHaveBeenCalled();
+  });
+});
+
+describe('chrome.tabs.onCreated listener', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetTabActivityMap();
+  });
+
+  it('should update activity and run cleanup when tab has id', async () => {
+    // @ts-expect-error - chrome is mocked
+    chrome.storage.sync.get.mockResolvedValue({
+      enabled: true,
+      idleTimeout: 30,
+      maxTabs: 50,
+      whitelist: [],
+      blacklist: [],
+      notificationsEnabled: false,
+    });
+
+    createdListener({ id: 1 });
+
+    await vi.waitFor(() => {
+      // @ts-expect-error - chrome is mocked
+      expect(chrome.tabs.query).toHaveBeenCalled();
+    });
+  });
+
+  it('should handle tab without id', () => {
+    createdListener({});
+    // Should not throw
+  });
+});
+
+describe('chrome.tabs.onRemoved listener', () => {
+  beforeEach(() => {
+    resetTabActivityMap();
+  });
+
+  it('should remove tab activity record', () => {
+    updateTabActivity(42);
+    expect(getLastActivity({ id: 42, lastAccessed: 0 })).toBeGreaterThan(0);
+
+    removedListener(42);
+    // After removal, should fallback to lastAccessed
+    expect(getLastActivity({ id: 42, lastAccessed: 0 })).toBe(0);
+  });
+});
+
+describe('chrome.storage.onChanged listener', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetTabActivityMap();
+  });
+
+  it('should call handleStorageChanged with changes and namespace', async () => {
+    // @ts-expect-error - chrome is mocked
+    chrome.storage.sync.get.mockResolvedValue({
+      enabled: true,
+      idleTimeout: 30,
+      maxTabs: 50,
+      whitelist: [],
+      blacklist: [],
+      notificationsEnabled: false,
+    });
+
+    storageChangedListener({ maxTabs: { newValue: 10 } }, 'sync');
+
+    await vi.waitFor(() => {
+      // @ts-expect-error - chrome is mocked
+      expect(chrome.tabs.query).toHaveBeenCalled();
+    });
+  });
+});
+
+describe('chrome.commands.onCommand listener', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetTabActivityMap();
+  });
+
+  it('should call handleCommand and catch errors', async () => {
+    // @ts-expect-error - chrome is mocked
+    chrome.storage.sync.get.mockResolvedValue({
+      enabled: true,
+      idleTimeout: 30,
+      maxTabs: 50,
+      whitelist: [],
+      blacklist: [],
+      notificationsEnabled: false,
+    });
+    // @ts-expect-error - chrome is mocked
+    chrome.tabs.query.mockResolvedValue([]);
+
+    commandListener('run-cleanup');
+
+    // Should not throw — errors are caught
+    await vi.waitFor(() => {
+      // @ts-expect-error - chrome is mocked
+      expect(chrome.tabs.query).toHaveBeenCalled();
+    });
   });
 });

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -194,26 +194,28 @@ chrome.alarms.create('cleanup', { periodInMinutes: 1 });
 
 chrome.alarms.onAlarm.addListener((alarm) => {
   if (alarm.name === 'cleanup') {
-    applyCleanupRules();
+    applyCleanupRules().catch((err) => console.error('Alarm cleanup error:', err));
   }
 });
 
 // Run immediate cleanup on startup/install
 chrome.runtime.onInstalled.addListener(() => {
-  applyCleanupRules();
+  applyCleanupRules().catch((err) => console.error('onInstalled cleanup error:', err));
 });
 
 chrome.runtime.onStartup.addListener(() => {
-  applyCleanupRules();
+  applyCleanupRules().catch((err) => console.error('onStartup cleanup error:', err));
 });
 
 // Listen for manual cleanup requests
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === 'runCleanup') {
-    (async () => {
-      await applyCleanupRules();
-      sendResponse({ status: 'started' });
-    })();
+    applyCleanupRules()
+      .then(() => sendResponse({ status: 'started' }))
+      .catch((err) => {
+        console.error('Message cleanup error:', err);
+        sendResponse({ status: 'error' });
+      });
     return true; // keep channel open for async sendResponse
   }
 });
@@ -238,7 +240,7 @@ chrome.tabs.onCreated.addListener((tab) => {
   if (tab.id) {
     updateTabActivity(tab.id);
   }
-  applyCleanupRules();
+  applyCleanupRules().catch((err) => console.error('onCreated cleanup error:', err));
 });
 
 // Clean up when a tab is closed
@@ -258,7 +260,7 @@ export function handleStorageChanged(
     }
     // Immediately apply cleanup rules when maxTabs changes (bug fix)
     if (changes.maxTabs) {
-      applyCleanupRules();
+      applyCleanupRules().catch((err) => console.error('Storage change cleanup error:', err));
     }
   }
 }
@@ -280,8 +282,8 @@ export async function handleCommand(command: string): Promise<void> {
   }
 }
 
-chrome.commands.onCommand.addListener(async (command) => {
-  await handleCommand(command);
+chrome.commands.onCommand.addListener((command) => {
+  handleCommand(command).catch((err) => console.error('Command error:', err));
 });
 
 // Initialize on startup

--- a/src/options/options.test.ts
+++ b/src/options/options.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { MockInstance } from 'vitest';
 import type { MockChrome } from '../__test-utils__/chrome-mock';
 
 // Mock Chrome APIs and DOM before importing the module
@@ -62,16 +63,16 @@ vi.stubGlobal(
 vi.stubGlobal('alert', vi.fn());
 
 // Mock window.matchMedia with addEventListener support
-const mockMatchMedia = vi.fn((query) => ({
+const mockMatchMedia = vi.fn((_query: string) => ({
   matches: false,
-  media: query,
+  media: '',
   onchange: null,
   addListener: vi.fn(),
   removeListener: vi.fn(),
   addEventListener: vi.fn(),
   removeEventListener: vi.fn(),
   dispatchEvent: vi.fn(),
-}));
+})) as unknown as MockInstance<(...args: unknown[]) => void>;
 vi.stubGlobal('window', {
   matchMedia: mockMatchMedia,
 });
@@ -659,7 +660,7 @@ describe('bindEventListeners', () => {
     if (elements) {
       bindEventListeners(elements);
       // Get the backup click handler
-      const backupCall = (mockButton.addEventListener as unknown as ReturnType<typeof vi.fn>).mock.calls.find((call: any) => call[0] === 'click');
+      const backupCall = (mockButton.addEventListener as unknown as ReturnType<typeof vi.fn>).mock.calls.find((call: unknown[]) => call[0] === 'click');
       if (backupCall) {
         const backupHandler = backupCall[1];
         await backupHandler();
@@ -786,7 +787,7 @@ describe('bindEventListeners', () => {
     if (elements) {
       bindEventListeners(elements);
       // Get the file change handler
-      const changeCall = (mockInput.addEventListener as unknown as ReturnType<typeof vi.fn>).mock.calls.find((call: any) => call[0] === 'change');
+      const changeCall = (mockInput.addEventListener as unknown as ReturnType<typeof vi.fn>).mock.calls.find((call: unknown[]) => call[0] === 'change');
       if (changeCall) {
         const changeHandler = changeCall[1];
         const mockEvent = {
@@ -854,7 +855,7 @@ describe('bindEventListeners', () => {
     if (elements) {
       bindEventListeners(elements);
       // Get the file change handler
-      const changeCall = (mockInput.addEventListener as unknown as ReturnType<typeof vi.fn>).mock.calls.find((call: any) => call[0] === 'change');
+      const changeCall = (mockInput.addEventListener as unknown as ReturnType<typeof vi.fn>).mock.calls.find((call: unknown[]) => call[0] === 'change');
       if (changeCall) {
         const changeHandler = changeCall[1];
         const mockEvent = {
@@ -923,7 +924,7 @@ describe('bindEventListeners', () => {
     if (elements) {
       bindEventListeners(elements);
       // Get the file change handler
-      const changeCall = (mockInput.addEventListener as unknown as ReturnType<typeof vi.fn>).mock.calls.find((call: any) => call[0] === 'change');
+      const changeCall = (mockInput.addEventListener as unknown as ReturnType<typeof vi.fn>).mock.calls.find((call: unknown[]) => call[0] === 'change');
       if (changeCall) {
         const changeHandler = changeCall[1];
         const mockEvent = {

--- a/src/options/options.test.ts
+++ b/src/options/options.test.ts
@@ -1,8 +1,9 @@
-// @ts-nocheck
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { MockChrome } from '../__test-utils__/chrome-mock';
 
 // Mock Chrome APIs and DOM before importing the module
 import './__mocks__/chrome';
+const chromeMock = chrome as unknown as MockChrome;
 import { applyTheme } from '../shared/theme';
 import {
   isValidSettings,
@@ -17,7 +18,7 @@ import { DEFAULT_SETTINGS } from '../shared/settings';
 
 // Get the mockDocumentElement from the global scope
 const mockDocumentElement = (
-  global as { document?: { documentElement?: { setAttribute: vi.Mock } } }
+  (global as unknown) as { document?: { documentElement?: { setAttribute: ReturnType<typeof vi.fn> } } }
 ).document?.documentElement;
 
 // Mock document.getElementById to return null initially
@@ -91,14 +92,12 @@ describe('applyTheme', () => {
   });
 
   it('should resolve system preference to light', () => {
-    // @ts-expect-error - window is mocked
     window.matchMedia.mockReturnValue({ matches: false });
     applyTheme('system');
     expect(mockDocumentElement?.setAttribute).toHaveBeenCalledWith('data-theme', 'light');
   });
 
   it('should resolve system preference to dark', () => {
-    // @ts-expect-error - window is mocked
     window.matchMedia.mockReturnValue({ matches: true });
     applyTheme('system');
     expect(mockDocumentElement?.setAttribute).toHaveBeenCalledWith('data-theme', 'dark');
@@ -297,8 +296,7 @@ describe('loadSettingsToForm', () => {
       restoreFile: {} as HTMLInputElement,
     };
 
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.get.mockResolvedValue({
+    chromeMock.storage.sync.get.mockResolvedValue({
       ...DEFAULT_SETTINGS,
       idleTimeout: 45,
       maxTabs: 100,
@@ -336,8 +334,7 @@ describe('loadSettingsToForm', () => {
       restoreFile: {} as HTMLInputElement,
     };
 
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.get.mockResolvedValue({
+    chromeMock.storage.sync.get.mockResolvedValue({
       ...DEFAULT_SETTINGS,
       theme: 'system',
     });
@@ -358,7 +355,7 @@ describe('saveSettingsFromForm', () => {
     const mockElements: OptionsFormElements = {
       form: {} as HTMLFormElement,
       idleTimeout: { value: '60' } as HTMLInputElement,
-      maxTabs: { value: '75' } as HTMLSelectElement,
+      maxTabs: { value: '75' } as HTMLInputElement,
       theme: { value: 'light' } as HTMLSelectElement,
       whitelist: { value: 'a.com\nb.com' } as HTMLTextAreaElement,
       blacklist: { value: 'c.com' } as HTMLTextAreaElement,
@@ -378,8 +375,7 @@ describe('saveSettingsFromForm', () => {
     expect(result.blacklist).toEqual(['c.com']);
     expect(result.whitelistedTabGroups).toEqual(['Work', 'Research']);
     expect(result.notificationsEnabled).toBe(true);
-    // @ts-expect-error - chrome is mocked
-    expect(chrome.storage.sync.set).toHaveBeenCalled();
+    expect(chromeMock.storage.sync.set).toHaveBeenCalled();
     expect(mockDocumentElement?.setAttribute).toHaveBeenCalledWith('data-theme', 'light');
   });
 
@@ -520,8 +516,7 @@ describe('saveSettingsFromForm', () => {
       restoreFile: {} as HTMLInputElement,
     };
 
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.get.mockResolvedValue({ enabled: true });
+    chromeMock.storage.sync.get.mockResolvedValue({ enabled: true });
 
     const result = await saveSettingsFromForm(mockElements);
 
@@ -543,8 +538,7 @@ describe('saveSettingsFromForm', () => {
       restoreFile: {} as HTMLInputElement,
     };
 
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.get.mockResolvedValue({ enabled: false });
+    chromeMock.storage.sync.get.mockResolvedValue({ enabled: false });
 
     const result = await saveSettingsFromForm(mockElements);
 
@@ -597,7 +591,6 @@ describe('bindEventListeners', () => {
       return elements[id] || null;
     });
 
-    // @ts-expect-error - window is mocked
     window.matchMedia.mockReturnValue({
       matches: false,
       addEventListener: vi.fn(),
@@ -611,7 +604,6 @@ describe('bindEventListeners', () => {
     expect(mockForm.addEventListener).toHaveBeenCalledWith('submit', expect.any(Function));
     expect(mockButton.addEventListener).toHaveBeenCalledWith('click', expect.any(Function));
     expect(mockInput.addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
-    // @ts-expect-error - window is mocked
     expect(window.matchMedia).toHaveBeenCalled();
   });
 
@@ -656,20 +648,18 @@ describe('bindEventListeners', () => {
       return elements[id] || null;
     });
 
-    // @ts-expect-error - window is mocked
     window.matchMedia.mockReturnValue({
       matches: false,
       addEventListener: vi.fn(),
     });
 
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.get.mockRejectedValue(new Error('Storage error'));
+    chromeMock.storage.sync.get.mockRejectedValue(new Error('Storage error'));
 
     const elements = getFormElements();
     if (elements) {
       bindEventListeners(elements);
       // Get the backup click handler
-      const backupCall = mockButton.addEventListener.mock.calls.find((call) => call[0] === 'click');
+      const backupCall = (mockButton.addEventListener as unknown as ReturnType<typeof vi.fn>).mock.calls.find((call: any) => call[0] === 'click');
       if (backupCall) {
         const backupHandler = backupCall[1];
         await backupHandler();
@@ -724,7 +714,6 @@ describe('bindEventListeners', () => {
       return elements[id] || null;
     });
 
-    // @ts-expect-error - window is mocked
     window.matchMedia.mockReturnValue({
       matches: false,
       addEventListener: vi.fn(),
@@ -734,7 +723,7 @@ describe('bindEventListeners', () => {
     if (elements) {
       bindEventListeners(elements);
       // Get the restore button click handler (second button with click listener)
-      const clickCalls = mockButton.addEventListener.mock.calls.filter(
+      const clickCalls = (mockButton.addEventListener as unknown as ReturnType<typeof vi.fn>).mock.calls.filter(
         (call) => call[0] === 'click',
       );
       if (clickCalls.length >= 2) {
@@ -788,7 +777,6 @@ describe('bindEventListeners', () => {
       return elements[id] || null;
     });
 
-    // @ts-expect-error - window is mocked
     window.matchMedia.mockReturnValue({
       matches: false,
       addEventListener: vi.fn(),
@@ -798,7 +786,7 @@ describe('bindEventListeners', () => {
     if (elements) {
       bindEventListeners(elements);
       // Get the file change handler
-      const changeCall = mockInput.addEventListener.mock.calls.find((call) => call[0] === 'change');
+      const changeCall = (mockInput.addEventListener as unknown as ReturnType<typeof vi.fn>).mock.calls.find((call: any) => call[0] === 'change');
       if (changeCall) {
         const changeHandler = changeCall[1];
         const mockEvent = {
@@ -857,7 +845,6 @@ describe('bindEventListeners', () => {
       return elements[id] || null;
     });
 
-    // @ts-expect-error - window is mocked
     window.matchMedia.mockReturnValue({
       matches: false,
       addEventListener: vi.fn(),
@@ -867,7 +854,7 @@ describe('bindEventListeners', () => {
     if (elements) {
       bindEventListeners(elements);
       // Get the file change handler
-      const changeCall = mockInput.addEventListener.mock.calls.find((call) => call[0] === 'change');
+      const changeCall = (mockInput.addEventListener as unknown as ReturnType<typeof vi.fn>).mock.calls.find((call: any) => call[0] === 'change');
       if (changeCall) {
         const changeHandler = changeCall[1];
         const mockEvent = {
@@ -927,7 +914,6 @@ describe('bindEventListeners', () => {
       return elements[id] || null;
     });
 
-    // @ts-expect-error - window is mocked
     window.matchMedia.mockReturnValue({
       matches: false,
       addEventListener: vi.fn(),
@@ -937,7 +923,7 @@ describe('bindEventListeners', () => {
     if (elements) {
       bindEventListeners(elements);
       // Get the file change handler
-      const changeCall = mockInput.addEventListener.mock.calls.find((call) => call[0] === 'change');
+      const changeCall = (mockInput.addEventListener as unknown as ReturnType<typeof vi.fn>).mock.calls.find((call: any) => call[0] === 'change');
       if (changeCall) {
         const changeHandler = changeCall[1];
         const mockEvent = {
@@ -996,14 +982,12 @@ describe('bindEventListeners', () => {
     });
 
     const mockAddEventListener = vi.fn();
-    // @ts-expect-error - window is mocked
     window.matchMedia.mockReturnValue({
       matches: false,
       addEventListener: mockAddEventListener,
     });
 
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.get.mockResolvedValue({ ...DEFAULT_SETTINGS, theme: 'system' });
+    chromeMock.storage.sync.get.mockResolvedValue({ ...DEFAULT_SETTINGS, theme: 'system' });
 
     const elements = getFormElements();
     if (elements) {
@@ -1026,8 +1010,7 @@ describe('initOptions', () => {
 
     await initOptions();
 
-    // @ts-expect-error - chrome is mocked
-    expect(chrome.storage.sync.get).not.toHaveBeenCalled();
+    expect(chromeMock.storage.sync.get).not.toHaveBeenCalled();
   });
 
   it('should initialize when all form elements exist', async () => {
@@ -1068,17 +1051,14 @@ describe('initOptions', () => {
       return elements[id] || null;
     });
 
-    // @ts-expect-error - window is mocked
     window.matchMedia.mockReturnValue({
       matches: false,
       addEventListener: vi.fn(),
     });
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.get.mockResolvedValue(DEFAULT_SETTINGS);
+    chromeMock.storage.sync.get.mockResolvedValue(DEFAULT_SETTINGS);
 
     await initOptions();
 
-    // @ts-expect-error - chrome is mocked
-    expect(chrome.storage.sync.get).toHaveBeenCalled();
+    expect(chromeMock.storage.sync.get).toHaveBeenCalled();
   });
 });

--- a/src/popup/popup.test.ts
+++ b/src/popup/popup.test.ts
@@ -310,7 +310,7 @@ describe('updateTabCount', () => {
       qrUrl: null as unknown as HTMLElement,
     };
 
-    chromeMock.tabs.query.mockImplementation((_query: any, callback: any) => {
+    chromeMock.tabs.query.mockImplementation((_query: unknown, callback: (...args: unknown[]) => void) => {
       callback([{ id: 1 } as chrome.tabs.Tab, { id: 2 } as chrome.tabs.Tab, { id: 3 } as chrome.tabs.Tab]);
     });
 
@@ -330,7 +330,7 @@ describe('updateTabCount', () => {
       qrUrl: null as unknown as HTMLElement,
     };
 
-    chromeMock.tabs.query.mockImplementation((_query: any, callback: any) => {
+    chromeMock.tabs.query.mockImplementation((_query: unknown, callback: (...args: unknown[]) => void) => {
       callback([]);
     });
 

--- a/src/popup/popup.test.ts
+++ b/src/popup/popup.test.ts
@@ -1,6 +1,7 @@
-// @ts-nocheck
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { MockChrome } from '../__test-utils__/chrome-mock';
 import './__mocks__/chrome';
+const chromeMock = chrome as unknown as MockChrome;
 import { applyTheme } from '../shared/theme';
 import { getDomain } from '../shared/domain';
 import {
@@ -76,15 +77,13 @@ vi.stubGlobal('document', {
 });
 
 // Mock chrome.runtime.openOptionsPage
-// @ts-expect-error - chrome is mocked
-chrome.runtime = {
-  ...chrome.runtime,
+chromeMock.runtime = {
+  ...chromeMock.runtime,
   openOptionsPage: vi.fn(),
 };
 
 // Mock chrome.runtime.sendMessage
-// @ts-expect-error - chrome is mocked
-chrome.runtime.sendMessage = vi.fn();
+chromeMock.runtime.sendMessage = vi.fn();
 
 describe('applyTheme', () => {
   beforeEach(() => {
@@ -102,13 +101,13 @@ describe('applyTheme', () => {
   });
 
   it('should resolve system preference to light', () => {
-    mockMatchMedia.mockReturnValue({ matches: false });
+    mockMatchMedia.mockReturnValue({ matches: false, media: '', onchange: null, addListener: vi.fn(), removeListener: vi.fn(), addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn() });
     applyTheme('system');
     expect(mockDocumentElement.setAttribute).toHaveBeenCalledWith('data-theme', 'light');
   });
 
   it('should resolve system preference to dark', () => {
-    mockMatchMedia.mockReturnValue({ matches: true });
+    mockMatchMedia.mockReturnValue({ matches: true, media: '', onchange: null, addListener: vi.fn(), removeListener: vi.fn(), addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn() });
     applyTheme('system');
     expect(mockDocumentElement.setAttribute).toHaveBeenCalledWith('data-theme', 'dark');
   });
@@ -150,10 +149,8 @@ describe('getTabStats', () => {
   });
 
   it('should return zero cleaned and dash for top domain with no tabs', async () => {
-    // @ts-expect-error - chrome is mocked
-    chrome.tabs.query.mockResolvedValue([]);
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.local.get.mockResolvedValue({ tabsCleanedToday: 0 });
+    chromeMock.tabs.query.mockResolvedValue([]);
+    chromeMock.storage.local.get.mockResolvedValue({ tabsCleanedToday: 0 });
 
     const stats = await getTabStats();
 
@@ -162,14 +159,12 @@ describe('getTabStats', () => {
   });
 
   it('should count tabs per domain correctly', async () => {
-    // @ts-expect-error - chrome is mocked
-    chrome.tabs.query.mockResolvedValue([
+    chromeMock.tabs.query.mockResolvedValue([
       { url: 'https://example.com/page1' },
       { url: 'https://example.com/page2' },
       { url: 'https://test.com/page' },
     ]);
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.local.get.mockResolvedValue({ tabsCleanedToday: 5 });
+    chromeMock.storage.local.get.mockResolvedValue({ tabsCleanedToday: 5 });
 
     const stats = await getTabStats();
 
@@ -178,14 +173,12 @@ describe('getTabStats', () => {
   });
 
   it('should skip tabs without URLs', async () => {
-    // @ts-expect-error - chrome is mocked
-    chrome.tabs.query.mockResolvedValue([
+    chromeMock.tabs.query.mockResolvedValue([
       { url: undefined },
       { url: 'https://example.com' },
       { url: null },
     ]);
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.local.get.mockResolvedValue({});
+    chromeMock.storage.local.get.mockResolvedValue({});
 
     const stats = await getTabStats();
 
@@ -193,10 +186,8 @@ describe('getTabStats', () => {
   });
 
   it('should return cleanedToday from storage', async () => {
-    // @ts-expect-error - chrome is mocked
-    chrome.tabs.query.mockResolvedValue([]);
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.local.get.mockResolvedValue({ tabsCleanedToday: 42 });
+    chromeMock.tabs.query.mockResolvedValue([]);
+    chromeMock.storage.local.get.mockResolvedValue({ tabsCleanedToday: 42 });
 
     const stats = await getTabStats();
 
@@ -204,10 +195,8 @@ describe('getTabStats', () => {
   });
 
   it('should return 0 for cleanedToday when not in storage', async () => {
-    // @ts-expect-error - chrome is mocked
-    chrome.tabs.query.mockResolvedValue([]);
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.local.get.mockResolvedValue({});
+    chromeMock.tabs.query.mockResolvedValue([]);
+    chromeMock.storage.local.get.mockResolvedValue({});
 
     const stats = await getTabStats();
 
@@ -215,8 +204,7 @@ describe('getTabStats', () => {
   });
 
   it('should handle Chrome API errors gracefully', async () => {
-    // @ts-expect-error - chrome is mocked
-    chrome.tabs.query.mockRejectedValue(new Error('API error'));
+    chromeMock.tabs.query.mockRejectedValue(new Error('API error'));
 
     const stats = await getTabStats();
 
@@ -225,16 +213,14 @@ describe('getTabStats', () => {
   });
 
   it('should identify most frequent domain', async () => {
-    // @ts-expect-error - chrome is mocked
-    chrome.tabs.query.mockResolvedValue([
+    chromeMock.tabs.query.mockResolvedValue([
       { url: 'https://a.com/page1' },
       { url: 'https://a.com/page2' },
       { url: 'https://b.com/page' },
       { url: 'https://b.com/page2' },
       { url: 'https://c.com/page' },
     ]);
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.local.get.mockResolvedValue({});
+    chromeMock.storage.local.get.mockResolvedValue({});
 
     const stats = await getTabStats();
 
@@ -320,11 +306,12 @@ describe('updateTabCount', () => {
       topDomain: {} as HTMLElement,
       toggleButton: {} as HTMLButtonElement,
       settingsButton: null,
+      qrCanvas: null as unknown as HTMLCanvasElement,
+      qrUrl: null as unknown as HTMLElement,
     };
 
-    // @ts-expect-error - chrome is mocked
-    chrome.tabs.query.mockImplementation((query, callback) => {
-      callback([{ id: 1 }, { id: 2 }, { id: 3 }]);
+    chromeMock.tabs.query.mockImplementation((_query: any, callback: any) => {
+      callback([{ id: 1 } as chrome.tabs.Tab, { id: 2 } as chrome.tabs.Tab, { id: 3 } as chrome.tabs.Tab]);
     });
 
     updateTabCount(mockElements);
@@ -339,10 +326,11 @@ describe('updateTabCount', () => {
       topDomain: {} as HTMLElement,
       toggleButton: {} as HTMLButtonElement,
       settingsButton: null,
+      qrCanvas: null as unknown as HTMLCanvasElement,
+      qrUrl: null as unknown as HTMLElement,
     };
 
-    // @ts-expect-error - chrome is mocked
-    chrome.tabs.query.mockImplementation((query, callback) => {
+    chromeMock.tabs.query.mockImplementation((_query: any, callback: any) => {
       callback([]);
     });
 
@@ -364,15 +352,15 @@ describe('updateStats', () => {
       topDomain: { textContent: '' } as HTMLElement,
       toggleButton: {} as HTMLButtonElement,
       settingsButton: null,
+      qrCanvas: null as unknown as HTMLCanvasElement,
+      qrUrl: null as unknown as HTMLElement,
     };
 
-    // @ts-expect-error - chrome is mocked
-    chrome.tabs.query.mockResolvedValue([
+    chromeMock.tabs.query.mockResolvedValue([
       { url: 'https://example.com/page1' },
       { url: 'https://example.com/page2' },
     ]);
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.local.get.mockResolvedValue({ tabsCleanedToday: 10 });
+    chromeMock.storage.local.get.mockResolvedValue({ tabsCleanedToday: 10 });
 
     await updateStats(mockElements);
 
@@ -387,12 +375,12 @@ describe('updateStats', () => {
       topDomain: { textContent: '' } as HTMLElement,
       toggleButton: {} as HTMLButtonElement,
       settingsButton: null,
+      qrCanvas: null as unknown as HTMLCanvasElement,
+      qrUrl: null as unknown as HTMLElement,
     };
 
-    // @ts-expect-error - chrome is mocked
-    chrome.tabs.query.mockResolvedValue([]);
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.local.get.mockResolvedValue({ tabsCleanedToday: 0 });
+    chromeMock.tabs.query.mockResolvedValue([]);
+    chromeMock.storage.local.get.mockResolvedValue({ tabsCleanedToday: 0 });
 
     await updateStats(mockElements);
 
@@ -407,10 +395,11 @@ describe('updateStats', () => {
       topDomain: { textContent: 'initial' } as HTMLElement,
       toggleButton: {} as HTMLButtonElement,
       settingsButton: null,
+      qrCanvas: null as unknown as HTMLCanvasElement,
+      qrUrl: null as unknown as HTMLElement,
     };
 
-    // @ts-expect-error - chrome is mocked
-    chrome.tabs.query.mockRejectedValue(new Error('API error'));
+    chromeMock.tabs.query.mockRejectedValue(new Error('API error'));
 
     await updateStats(mockElements);
 
@@ -427,6 +416,8 @@ describe('updateButton', () => {
       topDomain: {} as HTMLElement,
       toggleButton: { textContent: '', className: '' } as HTMLButtonElement,
       settingsButton: null,
+      qrCanvas: null as unknown as HTMLCanvasElement,
+      qrUrl: null as unknown as HTMLElement,
     };
 
     updateButton(mockElements, true);
@@ -442,6 +433,8 @@ describe('updateButton', () => {
       topDomain: {} as HTMLElement,
       toggleButton: { textContent: '', className: '' } as HTMLButtonElement,
       settingsButton: null,
+      qrCanvas: null as unknown as HTMLCanvasElement,
+      qrUrl: null as unknown as HTMLElement,
     };
 
     updateButton(mockElements, false);
@@ -463,21 +456,19 @@ describe('handleToggle', () => {
       topDomain: {} as HTMLElement,
       toggleButton: { textContent: '', className: '' } as HTMLButtonElement,
       settingsButton: null,
+      qrCanvas: null as unknown as HTMLCanvasElement,
+      qrUrl: null as unknown as HTMLElement,
     };
 
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.get.mockResolvedValue({ enabled: false });
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.set.mockResolvedValue(undefined);
-    // @ts-expect-error - chrome is mocked
-    chrome.runtime.sendMessage.mockResolvedValue(undefined);
+    chromeMock.storage.sync.get.mockResolvedValue({ enabled: false });
+    chromeMock.storage.sync.set.mockResolvedValue(undefined);
+    chromeMock.runtime.sendMessage.mockResolvedValue(undefined);
 
     await handleToggle(mockElements);
 
     expect(mockElements.toggleButton.textContent).toBe('Disable Auto Clean');
     expect(mockElements.toggleButton.className).toBe('enabled');
-    // @ts-expect-error - chrome is mocked
-    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ action: 'runCleanup' });
+    expect(chromeMock.runtime.sendMessage).toHaveBeenCalledWith({ action: 'runCleanup' });
   });
 
   it('should toggle enabled state without sending message when turning off', async () => {
@@ -487,19 +478,18 @@ describe('handleToggle', () => {
       topDomain: {} as HTMLElement,
       toggleButton: { textContent: '', className: '' } as HTMLButtonElement,
       settingsButton: null,
+      qrCanvas: null as unknown as HTMLCanvasElement,
+      qrUrl: null as unknown as HTMLElement,
     };
 
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.get.mockResolvedValue({ enabled: true });
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.set.mockResolvedValue(undefined);
+    chromeMock.storage.sync.get.mockResolvedValue({ enabled: true });
+    chromeMock.storage.sync.set.mockResolvedValue(undefined);
 
     await handleToggle(mockElements);
 
     expect(mockElements.toggleButton.textContent).toBe('Enable Auto Clean');
     expect(mockElements.toggleButton.className).toBe('disabled');
-    // @ts-expect-error - chrome is mocked
-    expect(chrome.runtime.sendMessage).not.toHaveBeenCalled();
+    expect(chromeMock.runtime.sendMessage).not.toHaveBeenCalled();
   });
 });
 
@@ -515,8 +505,7 @@ describe('initPopup', () => {
 
     await initPopup();
 
-    // @ts-expect-error - chrome is mocked
-    expect(chrome.storage.sync.get).not.toHaveBeenCalled();
+    expect(chromeMock.storage.sync.get).not.toHaveBeenCalled();
   });
 
   it('should initialize when all popup elements exist', async () => {
@@ -535,21 +524,18 @@ describe('initPopup', () => {
         'cleaned-count': mockCleanedCount,
         'top-domain': mockTopDomain,
         'toggle-clean': mockToggleButton,
-        'open-settings': null,
+        'open-settings': null as unknown as Element,
       };
       return elements[id] || null;
     });
 
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.get.mockResolvedValue({ enabled: true, theme: 'dark' });
-    // @ts-expect-error - chrome is mocked
-    chrome.tabs.query.mockResolvedValue([]);
+    chromeMock.storage.sync.get.mockResolvedValue({ enabled: true, theme: 'dark' });
+    chromeMock.tabs.query.mockResolvedValue([]);
 
     await initPopup();
 
     expect(mockDocumentElement.setAttribute).toHaveBeenCalledWith('data-theme', 'dark');
-    // @ts-expect-error - chrome is mocked
-    expect(chrome.storage.sync.get).toHaveBeenCalled();
+    expect(chromeMock.storage.sync.get).toHaveBeenCalled();
   });
 });
 
@@ -570,8 +556,7 @@ describe('generateQRCode', () => {
     };
 
     await generateQRCode(elements);
-    // @ts-expect-error - chrome is mocked
-    expect(chrome.tabs.query).not.toHaveBeenCalled();
+    expect(chromeMock.tabs.query).not.toHaveBeenCalled();
   });
 
   it('should return early when qrUrl is missing', async () => {
@@ -586,8 +571,7 @@ describe('generateQRCode', () => {
     };
 
     await generateQRCode(elements);
-    // @ts-expect-error - chrome is mocked
-    expect(chrome.tabs.query).not.toHaveBeenCalled();
+    expect(chromeMock.tabs.query).not.toHaveBeenCalled();
   });
 
   it('should show message for chrome:// URLs', async () => {
@@ -602,8 +586,7 @@ describe('generateQRCode', () => {
       qrUrl,
     };
 
-    // @ts-expect-error - chrome is mocked
-    chrome.tabs.query.mockResolvedValue([{ url: 'chrome://settings' }]);
+    chromeMock.tabs.query.mockResolvedValue([{ url: 'chrome://settings' }]);
 
     await generateQRCode(elements);
     expect(qrUrl.textContent).toBe('Cannot generate QR for this page');
@@ -621,8 +604,7 @@ describe('generateQRCode', () => {
       qrUrl,
     };
 
-    // @ts-expect-error - chrome is mocked
-    chrome.tabs.query.mockResolvedValue([{ url: 'chrome-extension://abcdefghijk/lmnop.html' }]);
+    chromeMock.tabs.query.mockResolvedValue([{ url: 'chrome-extension://abcdefghijk/lmnop.html' }]);
 
     await generateQRCode(elements);
     expect(qrUrl.textContent).toBe('Cannot generate QR for this page');
@@ -641,8 +623,7 @@ describe('generateQRCode', () => {
       qrUrl,
     };
 
-    // @ts-expect-error - chrome is mocked
-    chrome.tabs.query.mockResolvedValue([{ url: 'https://example.com/page' }]);
+    chromeMock.tabs.query.mockResolvedValue([{ url: 'https://example.com/page' }]);
 
     await generateQRCode(elements);
     expect(qrUrl.textContent).toBe('https://example.com/page');
@@ -661,8 +642,7 @@ describe('generateQRCode', () => {
     };
 
     const longUrl = 'https://example.com/very/long/path/with/many/segments/and/query/parameters?foo=bar&baz=qux';
-    // @ts-expect-error - chrome is mocked
-    chrome.tabs.query.mockResolvedValue([{ url: longUrl }]);
+    chromeMock.tabs.query.mockResolvedValue([{ url: longUrl }]);
 
     await generateQRCode(elements);
     expect(qrUrl.textContent).toBe('https://example.com/very/long/path/with/...');
@@ -680,8 +660,7 @@ describe('generateQRCode', () => {
       qrUrl,
     };
 
-    // @ts-expect-error - chrome is mocked
-    chrome.tabs.query.mockResolvedValue([]);
+    chromeMock.tabs.query.mockResolvedValue([]);
 
     await generateQRCode(elements);
     expect(qrUrl.textContent).toBe('Cannot generate QR for this page');
@@ -699,8 +678,7 @@ describe('generateQRCode', () => {
       qrUrl,
     };
 
-    // @ts-expect-error - chrome is mocked
-    chrome.tabs.query.mockResolvedValue([{ url: undefined }]);
+    chromeMock.tabs.query.mockResolvedValue([{ url: undefined }]);
 
     await generateQRCode(elements);
     expect(qrUrl.textContent).toBe('Cannot generate QR for this page');

--- a/src/shared/settings.test.ts
+++ b/src/shared/settings.test.ts
@@ -1,20 +1,17 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { MockChrome } from '../__test-utils__/chrome-mock';
 import './__mocks__/chrome';
+const chromeMock = chrome as unknown as MockChrome;
 import { getSettings, saveSettings, DEFAULT_SETTINGS } from './settings';
 
 describe('getSettings', () => {
   beforeEach(() => {
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.get.mockReset();
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.set.mockReset();
+    chromeMock.storage.sync.get.mockReset();
+    chromeMock.storage.sync.set.mockReset();
   });
 
   it('should return default settings when storage is empty', async () => {
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.get.mockResolvedValue({});
+    chromeMock.storage.sync.get.mockResolvedValue({});
 
     const settings = await getSettings();
 
@@ -22,8 +19,7 @@ describe('getSettings', () => {
   });
 
   it('should merge stored settings with defaults', async () => {
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.get.mockResolvedValue({
+    chromeMock.storage.sync.get.mockResolvedValue({
       enabled: true,
       maxTabs: 100,
     });
@@ -37,8 +33,7 @@ describe('getSettings', () => {
   });
 
   it('should override all default settings', async () => {
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.get.mockResolvedValue({
+    chromeMock.storage.sync.get.mockResolvedValue({
       enabled: true,
       idleTimeout: 60,
       maxTabs: 200,
@@ -66,8 +61,7 @@ describe('getSettings', () => {
   it('should handle storage error gracefully', async () => {
     // Suppress console.error output during this test
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.get.mockRejectedValue(new Error('Storage error'));
+    chromeMock.storage.sync.get.mockRejectedValue(new Error('Storage error'));
 
     const settings = await getSettings();
 
@@ -77,8 +71,7 @@ describe('getSettings', () => {
 
   it('should handle storage error with different error types', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.get.mockRejectedValue(new Error('Quota exceeded'));
+    chromeMock.storage.sync.get.mockRejectedValue(new Error('Quota exceeded'));
 
     const settings = await getSettings();
 
@@ -87,8 +80,7 @@ describe('getSettings', () => {
   });
 
   it('should return defaults when storage returns null-like value', async () => {
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.get.mockResolvedValue(null);
+    chromeMock.storage.sync.get.mockResolvedValue(null);
 
     const settings = await getSettings();
 
@@ -96,8 +88,7 @@ describe('getSettings', () => {
   });
 
   it('should merge partial storage data correctly', async () => {
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.get.mockResolvedValue({
+    chromeMock.storage.sync.get.mockResolvedValue({
       enabled: true,
       maxTabs: 100,
     });
@@ -113,17 +104,14 @@ describe('getSettings', () => {
 
 describe('saveSettings error handling', () => {
   beforeEach(() => {
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.get.mockReset();
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.set.mockReset();
+    chromeMock.storage.sync.get.mockReset();
+    chromeMock.storage.sync.set.mockReset();
   });
 
   it('should handle storage error gracefully', async () => {
     // Suppress console.error output during this test
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.set.mockRejectedValue(new Error('Storage error'));
+    chromeMock.storage.sync.set.mockRejectedValue(new Error('Storage error'));
 
     // Should not throw
     await saveSettings({ enabled: true });
@@ -135,8 +123,7 @@ describe('saveSettings error handling', () => {
 
   it('should handle different storage error types', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.set.mockRejectedValue(new Error('QuotaExceededError'));
+    chromeMock.storage.sync.set.mockRejectedValue(new Error('QuotaExceededError'));
 
     await saveSettings({ maxTabs: 200 });
 
@@ -146,48 +133,40 @@ describe('saveSettings error handling', () => {
 
   it('should handle invalid settings object', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.set.mockResolvedValue(undefined);
+    chromeMock.storage.sync.set.mockResolvedValue(undefined);
 
     // @ts-ignore - intentionally passing invalid partial settings
     await saveSettings({ invalidKey: 'value' });
 
     // Should attempt to save (Chrome storage ignores unknown keys)
-    // @ts-expect-error - chrome is mocked
-    expect(chrome.storage.sync.set).toHaveBeenCalled();
+    expect(chromeMock.storage.sync.set).toHaveBeenCalled();
     consoleErrorSpy.mockRestore();
   });
 });
 
 describe('saveSettings', () => {
   beforeEach(() => {
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.get.mockReset();
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.set.mockReset();
+    chromeMock.storage.sync.get.mockReset();
+    chromeMock.storage.sync.set.mockReset();
   });
 
   it('should save partial settings to storage', async () => {
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.set.mockResolvedValue(undefined);
+    chromeMock.storage.sync.set.mockResolvedValue(undefined);
 
     await saveSettings({ enabled: true, maxTabs: 100 });
 
-    // @ts-expect-error - chrome is mocked
-    expect(chrome.storage.sync.set).toHaveBeenCalledWith({
+    expect(chromeMock.storage.sync.set).toHaveBeenCalledWith({
       enabled: true,
       maxTabs: 100,
     });
   });
 
   it('should save single setting', async () => {
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.set.mockResolvedValue(undefined);
+    chromeMock.storage.sync.set.mockResolvedValue(undefined);
 
     await saveSettings({ enabled: false });
 
-    // @ts-expect-error - chrome is mocked
-    expect(chrome.storage.sync.set).toHaveBeenCalledWith({
+    expect(chromeMock.storage.sync.set).toHaveBeenCalledWith({
       enabled: false,
     });
   });
@@ -195,8 +174,7 @@ describe('saveSettings', () => {
   it('should handle storage error gracefully', async () => {
     // Suppress console.error output during this test
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.set.mockRejectedValue(new Error('Storage error'));
+    chromeMock.storage.sync.set.mockRejectedValue(new Error('Storage error'));
 
     // Should not throw
     await saveSettings({ enabled: true });
@@ -207,32 +185,28 @@ describe('saveSettings', () => {
   });
 
   it('should save array settings', async () => {
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.set.mockResolvedValue(undefined);
+    chromeMock.storage.sync.set.mockResolvedValue(undefined);
 
     await saveSettings({
       whitelist: ['a.com', 'b.com'],
       blacklist: ['c.com'],
     });
 
-    // @ts-expect-error - chrome is mocked
-    expect(chrome.storage.sync.set).toHaveBeenCalledWith({
+    expect(chromeMock.storage.sync.set).toHaveBeenCalledWith({
       whitelist: ['a.com', 'b.com'],
       blacklist: ['c.com'],
     });
   });
 
   it('should save boolean settings', async () => {
-    // @ts-expect-error - chrome is mocked
-    chrome.storage.sync.set.mockResolvedValue(undefined);
+    chromeMock.storage.sync.set.mockResolvedValue(undefined);
 
     await saveSettings({
       notificationsEnabled: true,
       enabled: false,
     });
 
-    // @ts-expect-error - chrome is mocked
-    expect(chrome.storage.sync.set).toHaveBeenCalledWith({
+    expect(chromeMock.storage.sync.set).toHaveBeenCalledWith({
       notificationsEnabled: true,
       enabled: false,
     });


### PR DESCRIPTION
Fixes #26

Wrap all fire-and-forget async calls in event listeners with `.catch()` to prevent `UnhandledPromiseRejection` errors that crash the MV3 service worker.

**Affected listeners:**
- `chrome.alarms.onAlarm`
- `chrome.runtime.onInstalled`
- `chrome.runtime.onStartup`
- `chrome.runtime.onMessage` (refactored IIFE to `.then()/.catch()`)
- `chrome.tabs.onCreated`
- `chrome.storage.onChanged` (via `handleStorageChanged`)
- `chrome.commands.onCommand`

Each now logs errors to console instead of crashing the service worker.

The `onMessage` listener now sends `{ status: "error" }` on failure instead of silently dropping the response.

**Verification:** 277 tests passing, lint clean.