### PR TITLE
fix: handle unhandled promise rejections in async event listeners

### DIFF
--- a/src/background/index.test.ts
+++ b/src/background/index.test.ts
@@ -1647,7 +1647,7 @@ describe('chrome.runtime.onMessage runCleanup', () => {
     // sendResponse should not fire synchronously
     expect(sendResponse).not.toHaveBeenCalled();
 
-    // Wait for the async IIFE to complete
+    // Wait for the async promise chain to complete
     await vi.waitFor(() => {
       expect(sendResponse).toHaveBeenCalledWith({ status: 'started' });
     });
@@ -1663,5 +1663,116 @@ describe('chrome.runtime.onMessage runCleanup', () => {
 
     expect(result).toBeUndefined();
     expect(sendResponse).not.toHaveBeenCalled();
+  });
+});
+
+// Capture event listeners registered during module import
+// @ts-expect-error - chrome is mocked
+const createdListener = chrome.tabs.onCreated.addListener.mock.calls[0][0];
+// @ts-expect-error - chrome is mocked
+const removedListener = chrome.tabs.onRemoved.addListener.mock.calls[0][0];
+// @ts-expect-error - chrome is mocked
+const storageChangedListener = chrome.storage.onChanged.addListener.mock.calls[0][0];
+// @ts-expect-error - chrome is mocked
+const commandListener = chrome.commands.onCommand.addListener.mock.calls[0][0];
+
+describe('chrome.tabs.onCreated listener', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetTabActivityMap();
+  });
+
+  it('should update activity and run cleanup when tab has id', async () => {
+    // @ts-expect-error - chrome is mocked
+    chrome.storage.sync.get.mockResolvedValue({
+      enabled: true,
+      idleTimeout: 30,
+      maxTabs: 50,
+      whitelist: [],
+      blacklist: [],
+      notificationsEnabled: false,
+    });
+
+    createdListener({ id: 1 });
+
+    await vi.waitFor(() => {
+      // @ts-expect-error - chrome is mocked
+      expect(chrome.tabs.query).toHaveBeenCalled();
+    });
+  });
+
+  it('should handle tab without id', () => {
+    createdListener({});
+    // Should not throw
+  });
+});
+
+describe('chrome.tabs.onRemoved listener', () => {
+  beforeEach(() => {
+    resetTabActivityMap();
+  });
+
+  it('should remove tab activity record', () => {
+    updateTabActivity(42);
+    expect(getLastActivity({ id: 42, lastAccessed: 0 })).toBeGreaterThan(0);
+
+    removedListener(42);
+    // After removal, should fallback to lastAccessed
+    expect(getLastActivity({ id: 42, lastAccessed: 0 })).toBe(0);
+  });
+});
+
+describe('chrome.storage.onChanged listener', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetTabActivityMap();
+  });
+
+  it('should call handleStorageChanged with changes and namespace', async () => {
+    // @ts-expect-error - chrome is mocked
+    chrome.storage.sync.get.mockResolvedValue({
+      enabled: true,
+      idleTimeout: 30,
+      maxTabs: 50,
+      whitelist: [],
+      blacklist: [],
+      notificationsEnabled: false,
+    });
+
+    storageChangedListener({ maxTabs: { newValue: 10 } }, 'sync');
+
+    await vi.waitFor(() => {
+      // @ts-expect-error - chrome is mocked
+      expect(chrome.tabs.query).toHaveBeenCalled();
+    });
+  });
+});
+
+describe('chrome.commands.onCommand listener', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetTabActivityMap();
+  });
+
+  it('should call handleCommand and catch errors', async () => {
+    // @ts-expect-error - chrome is mocked
+    chrome.storage.sync.get.mockResolvedValue({
+      enabled: true,
+      idleTimeout: 30,
+      maxTabs: 50,
+      whitelist: [],
+      blacklist: [],
+      notificationsEnabled: false,
+    });
+    // @ts-expect-error - chrome is mocked
+    chrome.tabs.query.mockResolvedValue([]);
+
+    commandListener('run-cleanup');
+
+    // Should not throw — errors are caught
+    await vi.waitFor(() => {
+      // @ts-expect-error - chrome is mocked
+      expect(chrome.tabs.query).toHaveBeenCalled();
+    });
   });
 });

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -194,26 +194,28 @@ chrome.alarms.create('cleanup', { periodInMinutes: 1 });
 
 chrome.alarms.onAlarm.addListener((alarm) => {
   if (alarm.name === 'cleanup') {
-    applyCleanupRules();
+    applyCleanupRules().catch((err) => console.error('Alarm cleanup error:', err));
   }
 });
 
 // Run immediate cleanup on startup/install
 chrome.runtime.onInstalled.addListener(() => {
-  applyCleanupRules();
+  applyCleanupRules().catch((err) => console.error('onInstalled cleanup error:', err));
 });
 
 chrome.runtime.onStartup.addListener(() => {
-  applyCleanupRules();
+  applyCleanupRules().catch((err) => console.error('onStartup cleanup error:', err));
 });
 
 // Listen for manual cleanup requests
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === 'runCleanup') {
-    (async () => {
-      await applyCleanupRules();
-      sendResponse({ status: 'started' });
-    })();
+    applyCleanupRules()
+      .then(() => sendResponse({ status: 'started' }))
+      .catch((err) => {
+        console.error('Message cleanup error:', err);
+        sendResponse({ status: 'error' });
+      });
     return true; // keep channel open for async sendResponse
   }
 });
@@ -238,7 +240,7 @@ chrome.tabs.onCreated.addListener((tab) => {
   if (tab.id) {
     updateTabActivity(tab.id);
   }
-  applyCleanupRules();
+  applyCleanupRules().catch((err) => console.error('onCreated cleanup error:', err));
 });
 
 // Clean up when a tab is closed
@@ -258,7 +260,7 @@ export function handleStorageChanged(
     }
     // Immediately apply cleanup rules when maxTabs changes (bug fix)
     if (changes.maxTabs) {
-      applyCleanupRules();
+      applyCleanupRules().catch((err) => console.error('Storage change cleanup error:', err));
     }
   }
 }
@@ -280,8 +282,8 @@ export async function handleCommand(command: string): Promise<void> {
   }
 }
 
-chrome.commands.onCommand.addListener(async (command) => {
-  await handleCommand(command);
+chrome.commands.onCommand.addListener((command) => {
+  handleCommand(command).catch((err) => console.error('Command error:', err));
 });
 
 // Initialize on startup


### PR DESCRIPTION
Fixes #26

Wrap all fire-and-forget async calls in event listeners with `.catch()` to prevent `UnhandledPromiseRejection` errors that crash the MV3 service worker.

**Affected listeners:**
- `chrome.alarms.onAlarm`
- `chrome.runtime.onInstalled`
- `chrome.runtime.onStartup`
- `chrome.runtime.onMessage` (refactored IIFE to `.then()/.catch()`)
- `chrome.tabs.onCreated`
- `chrome.storage.onChanged` (via `handleStorageChanged`)
- `chrome.commands.onCommand`

Each now logs errors to console instead of crashing the service worker.

The `onMessage` listener now sends `{ status: "error" }` on failure instead of silently dropping the response.

**Verification:**
- 282 tests passing
- ESLint clean
- Webpack build successful