### PR TITLE
fix: pass getLastActivity into getDuplicateTabs for custom activity timestamps

### DIFF
--- a/src/background/cleanup.test.ts
+++ b/src/background/cleanup.test.ts
@@ -235,6 +235,24 @@ describe('Rule 5 — Duplicate tabs', () => {
     const r = run({ tabs: [t1, t2] });
     expect(r.tabIdsToClose).toEqual([]);
   });
+
+  it('uses custom getLastActivity for duplicate sorting', () => {
+    // Tab 1 has fresh lastAccessed but custom activity says old
+    // Tab 2 has old lastAccessed but custom activity says fresh
+    const customActivity = new Map<number, number>([
+      [1, Date.now() - 100_000], // custom: tab 1 is old
+      [2, Date.now()], // custom: tab 2 is recent
+    ]);
+    const t1 = tab({ id: 1, lastAccessed: Date.now(), url: 'https://example.com' });
+    const t2 = tab({ id: 2, lastAccessed: Date.now() - 100_000, url: 'https://example.com' });
+    const r = run({
+      tabs: [t1, t2],
+      getLastActivity: (t) => customActivity.get(t.id ?? -1) ?? t.lastAccessed ?? 0,
+    });
+    // Without custom activity, tab 2 would be closed (older lastAccessed).
+    // With custom activity, tab 1 should be closed (older custom activity).
+    expect(r.tabIdsToClose).toEqual([1]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/background/cleanup.ts
+++ b/src/background/cleanup.ts
@@ -4,10 +4,15 @@ import { getDomain, domainMatches } from '../shared/domain';
 /**
  * Identifies duplicate tabs with the same URL.
  * Keeps the most recently accessed tab (or active tab) and marks others as duplicates.
+ * Uses getLastActivity callback for custom activity timestamps when available.
  * @param tabs - Array of Chrome tabs to check
+ * @param getLastActivity - Callback to get last activity timestamp for a tab
  * @returns Array of tab IDs to close (duplicates)
  */
-export function getDuplicateTabs(tabs: chrome.tabs.Tab[]): number[] {
+export function getDuplicateTabs(
+  tabs: chrome.tabs.Tab[],
+  getLastActivity: (tab: chrome.tabs.Tab) => number,
+): number[] {
   const duplicates: number[] = [];
   const urlMap: Map<string, chrome.tabs.Tab[]> = new Map();
 
@@ -24,7 +29,7 @@ export function getDuplicateTabs(tabs: chrome.tabs.Tab[]): number[] {
       tabsWithSameUrl.sort((a, b) => {
         if (a.active && !b.active) return -1;
         if (!a.active && b.active) return 1;
-        return (b.lastAccessed || 0) - (a.lastAccessed || 0);
+        return getLastActivity(b) - getLastActivity(a);
       });
       tabsWithSameUrl.slice(1).forEach((tab) => {
         if (tab.id && !tab.active && !tab.pinned) duplicates.push(tab.id);
@@ -107,7 +112,7 @@ export function computeCleanup(input: CleanupInput): CleanupResult {
   });
 
   // 5. Duplicate tabs
-  const duplicateIds = getDuplicateTabs(tabs);
+  const duplicateIds = getDuplicateTabs(tabs, getLastActivity);
   duplicateIds.forEach((id) => {
     const tab = tabs.find((t) => t.id === id);
     if (tab && !tab.active && !tab.pinned) {

--- a/src/background/index.test.ts
+++ b/src/background/index.test.ts
@@ -235,7 +235,7 @@ describe('getDuplicateTabs', () => {
       createTab({ id: 1, url: 'https://a.com', lastAccessed: 100 }),
       createTab({ id: 2, url: 'https://b.com', lastAccessed: 200 }),
     ];
-    expect(getDuplicateTabs(tabs)).toEqual([]);
+    expect(getDuplicateTabs(tabs, (t) => t.lastAccessed || 0)).toEqual([]);
   });
 
   it('should identify duplicate URLs', () => {
@@ -244,7 +244,7 @@ describe('getDuplicateTabs', () => {
       createTab({ id: 2, url: 'https://example.com', lastAccessed: 200 }),
       createTab({ id: 3, url: 'https://example.com', lastAccessed: 150 }),
     ];
-    const duplicates = getDuplicateTabs(tabs);
+    const duplicates = getDuplicateTabs(tabs, (t) => t.lastAccessed || 0);
     expect(duplicates).toHaveLength(2);
     expect(duplicates).not.toContain(2);
   });
@@ -254,7 +254,7 @@ describe('getDuplicateTabs', () => {
       createTab({ id: 1, url: 'https://example.com', active: true, lastAccessed: 50 }),
       createTab({ id: 2, url: 'https://example.com', lastAccessed: 200 }),
     ];
-    const duplicates = getDuplicateTabs(tabs);
+    const duplicates = getDuplicateTabs(tabs, (t) => t.lastAccessed || 0);
     expect(duplicates).toEqual([2]);
   });
 
@@ -264,18 +264,18 @@ describe('getDuplicateTabs', () => {
       createTab({ id: 2, url: undefined, lastAccessed: 200 }),
       createTab({ id: 3, url: 'https://example.com', lastAccessed: 150 }),
     ];
-    const duplicates = getDuplicateTabs(tabs);
+    const duplicates = getDuplicateTabs(tabs, (t) => t.lastAccessed || 0);
     // Tab 1 is older (100) than tab 3 (150), so tab 1 is the duplicate
     expect(duplicates).toEqual([1]);
   });
 
   it('should handle single tab', () => {
     const tabs = [createTab({ id: 1, url: 'https://example.com', lastAccessed: 100 })];
-    expect(getDuplicateTabs(tabs)).toEqual([]);
+    expect(getDuplicateTabs(tabs, (t) => t.lastAccessed || 0)).toEqual([]);
   });
 
   it('should handle empty array', () => {
-    expect(getDuplicateTabs([])).toEqual([]);
+    expect(getDuplicateTabs([], (t) => t.lastAccessed || 0)).toEqual([]);
   });
 
   it('should not include active tabs in duplicates', () => {
@@ -284,7 +284,7 @@ describe('getDuplicateTabs', () => {
       createTab({ id: 2, url: 'https://example.com', lastAccessed: 200 }),
       createTab({ id: 3, url: 'https://example.com', lastAccessed: 150 }),
     ];
-    const duplicates = getDuplicateTabs(tabs);
+    const duplicates = getDuplicateTabs(tabs, (t) => t.lastAccessed || 0);
     expect(duplicates).not.toContain(1);
     expect(duplicates).toContain(2);
     expect(duplicates).toContain(3);
@@ -1060,7 +1060,7 @@ describe('getDuplicateTabs edge cases', () => {
       { id: 2, url: 'https://example.com#section2', active: false, lastAccessed: 200 },
       { id: 3, url: 'https://example.com', active: false, lastAccessed: 150 },
     ];
-    const duplicates = getDuplicateTabs(tabs as chrome.tabs.Tab[]);
+    const duplicates = getDuplicateTabs(tabs as chrome.tabs.Tab[], (t) => t.lastAccessed || 0);
     // All URLs are different due to fragments, so no duplicates
     expect(duplicates.length).toBe(0);
   });
@@ -1071,7 +1071,7 @@ describe('getDuplicateTabs edge cases', () => {
       { id: 1, url: 'https://example.com?a=1', active: false, lastAccessed: 100 },
       { id: 2, url: 'https://example.com?b=2', active: false, lastAccessed: 200 },
     ];
-    const duplicates = getDuplicateTabs(tabs as chrome.tabs.Tab[]);
+    const duplicates = getDuplicateTabs(tabs as chrome.tabs.Tab[], (t) => t.lastAccessed || 0);
     expect(duplicates.length).toBe(0);
   });
 
@@ -1080,7 +1080,7 @@ describe('getDuplicateTabs edge cases', () => {
       { id: 1, url: 'https://example.com', active: true, lastAccessed: 100 },
       { id: 2, url: 'https://example.com', active: false, lastAccessed: 200 },
     ];
-    const duplicates = getDuplicateTabs(tabs as chrome.tabs.Tab[]);
+    const duplicates = getDuplicateTabs(tabs as chrome.tabs.Tab[], (t) => t.lastAccessed || 0);
     expect(duplicates).toContain(2);
   });
 
@@ -1095,7 +1095,7 @@ describe('getDuplicateTabs edge cases', () => {
       });
     }
     const startTime = Date.now();
-    const duplicates = getDuplicateTabs(tabs as chrome.tabs.Tab[]);
+    const duplicates = getDuplicateTabs(tabs as chrome.tabs.Tab[], (t) => t.lastAccessed || 0);
     const elapsed = Date.now() - startTime;
     expect(elapsed).toBeLessThan(100);
     expect(duplicates.length).toBeGreaterThan(0);
@@ -1106,7 +1106,7 @@ describe('getDuplicateTabs edge cases', () => {
       { id: 1, url: 'chrome://settings', active: false, lastAccessed: 100 },
       { id: 2, url: 'chrome://settings', active: false, lastAccessed: 200 },
     ];
-    const duplicates = getDuplicateTabs(tabs as chrome.tabs.Tab[]);
+    const duplicates = getDuplicateTabs(tabs as chrome.tabs.Tab[], (t) => t.lastAccessed || 0);
     expect(duplicates).toContain(1);
   });
 
@@ -1116,7 +1116,7 @@ describe('getDuplicateTabs edge cases', () => {
       { id: 1, url: 'https://example.com', active: false, pinned: true, lastAccessed: 200 },
       { id: 2, url: 'https://example.com', active: false, pinned: false, lastAccessed: 100 },
     ];
-    const duplicates = getDuplicateTabs(tabs as chrome.tabs.Tab[]);
+    const duplicates = getDuplicateTabs(tabs as chrome.tabs.Tab[], (t) => t.lastAccessed || 0);
     expect(duplicates).not.toContain(1);
     expect(duplicates).toContain(2);
   });
@@ -1128,7 +1128,7 @@ describe('getDuplicateTabs edge cases', () => {
       { id: 2, url: 'https://example.com', active: false, pinned: false, lastAccessed: 100 },
       { id: 3, url: 'https://example.com', active: false, pinned: false, lastAccessed: 150 },
     ];
-    const duplicates = getDuplicateTabs(tabs as chrome.tabs.Tab[]);
+    const duplicates = getDuplicateTabs(tabs as chrome.tabs.Tab[], (t) => t.lastAccessed || 0);
     expect(duplicates).not.toContain(1);
     expect(duplicates).not.toContain(3); // newest non-pinned is kept
     expect(duplicates).toContain(2);


### PR DESCRIPTION
Fixes #27

`getDuplicateTabs` sorted duplicates by `tab.lastAccessed`, ignoring the custom activity timestamps tracked in `tabActivityMap`. This could close recently-used tabs whose native `lastAccessed` was stale.

**Changes:**
- `getDuplicateTabs` now accepts a `getLastActivity` callback parameter
- Sorts by `getLastActivity(tab)` instead of `tab.lastAccessed`
- `computeCleanup` passes its `getLastActivity` through to `getDuplicateTabs`
- All direct `getDuplicateTabs` calls updated with default callback
- New test: custom activity overrides native lastAccessed for duplicate sorting

**Verification:** 283 tests passing, lint clean, build successful