### PR TITLE
refactor: convert updateTabCount from deprecated callback to async/await

### DIFF
--- a/src/popup/popup.test.ts
+++ b/src/popup/popup.test.ts
@@ -318,7 +318,7 @@ describe('updateTabCount', () => {
     vi.clearAllMocks();
   });
 
-  it('should update tab count display', () => {
+  it('should update tab count display', async () => {
     const mockElements: PopupElements = {
       tabCount: { textContent: '' } as HTMLElement,
       cleanedCount: {} as HTMLElement,
@@ -328,16 +328,14 @@ describe('updateTabCount', () => {
       qrCanvas: null as unknown as HTMLCanvasElement,
       qrUrl: null as unknown as HTMLElement,
     };
-    chromeMock.tabs.query.mockImplementation((query: any, callback: any) => {
-      callback([{ id: 1 }, { id: 2 }, { id: 3 }]);
-    });
+    chromeMock.tabs.query.mockResolvedValue([{ id: 1 }, { id: 2 }, { id: 3 }]);
 
-    updateTabCount(mockElements);
+    await updateTabCount(mockElements);
 
     expect(mockElements.tabCount.textContent).toBe('3');
   });
 
-  it('should show 0 for no tabs', () => {
+  it('should show 0 for no tabs', async () => {
     const mockElements: PopupElements = {
       tabCount: { textContent: '' } as HTMLElement,
       cleanedCount: {} as HTMLElement,
@@ -347,11 +345,26 @@ describe('updateTabCount', () => {
       qrCanvas: null as unknown as HTMLCanvasElement,
       qrUrl: null as unknown as HTMLElement,
     };
-    chromeMock.tabs.query.mockImplementation((query: any, callback: any) => {
-      callback([]);
-    });
+    chromeMock.tabs.query.mockResolvedValue([]);
 
-    updateTabCount(mockElements);
+    await updateTabCount(mockElements);
+
+    expect(mockElements.tabCount.textContent).toBe('0');
+  });
+
+  it('should show 0 on error', async () => {
+    const mockElements: PopupElements = {
+      tabCount: { textContent: '' } as HTMLElement,
+      cleanedCount: {} as HTMLElement,
+      topDomain: {} as HTMLElement,
+      toggleButton: {} as HTMLButtonElement,
+      settingsButton: null,
+      qrCanvas: null as unknown as HTMLCanvasElement,
+      qrUrl: null as unknown as HTMLElement,
+    };
+    chromeMock.tabs.query.mockRejectedValue(new Error('API error'));
+
+    await updateTabCount(mockElements);
 
     expect(mockElements.tabCount.textContent).toBe('0');
   });

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -88,10 +88,13 @@ export function getPopupElements(): PopupElements | null {
  * Updates the tab count display.
  * @param elements - Popup elements
  */
-export function updateTabCount(elements: PopupElements): void {
-  chrome.tabs.query({}, (tabs) => {
+export async function updateTabCount(elements: PopupElements): Promise<void> {
+  try {
+    const tabs = await chrome.tabs.query({});
     elements.tabCount.textContent = tabs.length.toString();
-  });
+  } catch {
+    elements.tabCount.textContent = '0';
+  }
 }
 
 /**
@@ -191,7 +194,7 @@ export async function initPopup(): Promise<void> {
   applyTheme(settings.theme);
 
   // Update tab count and stats on load
-  updateTabCount(elements);
+  await updateTabCount(elements);
   await updateStats(elements);
 
   // Toggle button click


### PR DESCRIPTION
## Summary

Convert `updateTabCount` in `src/popup/popup.ts` from deprecated callback pattern to async/await to match the rest of the codebase.

## Changes

- **`src/popup/popup.ts`**:
  - Convert `updateTabCount` from callback-based `chrome.tabs.query()` to async/await
  - Add error handling with fallback to "0" on API failure
  - Update `initPopup` to await the now-async `updateTabCount` call

- **`src/popup/popup.test.ts`**:
  - Convert `updateTabCount` tests from callback pattern to async/await
  - Add new test for error handling scenario

## Testing

All 284 tests pass (including new error handling test).

Closes #28