### PR TITLE
refactor: use storage.local for large domain lists to avoid sync quota limits

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -268,6 +268,11 @@ export function handleStorageChanged(
     if (changes.maxTabs) {
       applyCleanupRules().catch((err) => console.error('Storage change cleanup error:', err));
     }
+  } else if (namespace === 'local') {
+    // Domain lists changed in local storage - re-apply cleanup rules
+    if (changes.whitelist || changes.blacklist || changes.whitelistedTabGroups) {
+      applyCleanupRules().catch((err) => console.error('Local storage change cleanup error:', err));
+    }
   }
 }
 

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -232,7 +232,8 @@ export function bindEventListeners(elements: OptionsFormElements): void {
       alert('Settings restored successfully!');
     } catch (error) {
       console.error('Error importing settings:', error);
-      alert('Error importing settings. Make sure the file is valid JSON.');
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      alert(`Failed to import settings: ${message}`);
     }
 
     // Reset file input
@@ -246,7 +247,8 @@ export function bindEventListeners(elements: OptionsFormElements): void {
       alert('Settings saved');
     } catch (error) {
       console.error('Error saving settings in options:', error);
-      alert('Error saving settings');
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      alert(`Failed to save settings: ${message}`);
     }
   });
 }

--- a/src/shared/settings.test.ts
+++ b/src/shared/settings.test.ts
@@ -9,10 +9,13 @@ describe('getSettings', () => {
   beforeEach(() => {
     chromeMock.storage.sync.get.mockReset();
     chromeMock.storage.sync.set.mockReset();
+    chromeMock.storage.local.get.mockReset();
+    chromeMock.storage.local.set.mockReset();
   });
 
   it('should return default settings when storage is empty', async () => {
     chromeMock.storage.sync.get.mockResolvedValue({});
+    chromeMock.storage.local.get.mockResolvedValue({});
 
     const settings = await getSettings();
 
@@ -24,6 +27,7 @@ describe('getSettings', () => {
       enabled: true,
       maxTabs: 100,
     });
+    chromeMock.storage.local.get.mockResolvedValue({});
 
     const settings = await getSettings();
 
@@ -38,11 +42,13 @@ describe('getSettings', () => {
       enabled: true,
       idleTimeout: 60,
       maxTabs: 200,
+      notificationsEnabled: false,
+      theme: 'dark',
+    });
+    chromeMock.storage.local.get.mockResolvedValue({
       whitelist: ['test.com'],
       blacklist: ['bad.com'],
       whitelistedTabGroups: ['Work'],
-      notificationsEnabled: false,
-      theme: 'dark',
     });
 
     const settings = await getSettings();
@@ -60,9 +66,9 @@ describe('getSettings', () => {
   });
 
   it('should handle storage error gracefully', async () => {
-    // Suppress console.error output during this test
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     chromeMock.storage.sync.get.mockRejectedValue(new Error('Storage error'));
+    chromeMock.storage.local.get.mockResolvedValue({});
 
     const settings = await getSettings();
 
@@ -73,6 +79,7 @@ describe('getSettings', () => {
   it('should handle storage error with different error types', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     chromeMock.storage.sync.get.mockRejectedValue(new Error('Quota exceeded'));
+    chromeMock.storage.local.get.mockResolvedValue({});
 
     const settings = await getSettings();
 
@@ -82,6 +89,7 @@ describe('getSettings', () => {
 
   it('should return defaults when storage returns null-like value', async () => {
     chromeMock.storage.sync.get.mockResolvedValue(null);
+    chromeMock.storage.local.get.mockResolvedValue(null);
 
     const settings = await getSettings();
 
@@ -93,6 +101,7 @@ describe('getSettings', () => {
       enabled: true,
       maxTabs: 100,
     });
+    chromeMock.storage.local.get.mockResolvedValue({});
 
     const settings = await getSettings();
 
@@ -101,46 +110,55 @@ describe('getSettings', () => {
     expect(settings.idleTimeout).toBe(DEFAULT_SETTINGS.idleTimeout);
     expect(settings.whitelist).toEqual([]);
   });
+
+  it('should read domain lists from local storage', async () => {
+    chromeMock.storage.sync.get.mockResolvedValue({});
+    chromeMock.storage.local.get.mockResolvedValue({
+      whitelist: ['example.com', 'test.org'],
+      blacklist: ['bad.com'],
+      whitelistedTabGroups: ['Important'],
+    });
+
+    const settings = await getSettings();
+
+    expect(settings.whitelist).toEqual(['example.com', 'test.org']);
+    expect(settings.blacklist).toEqual(['bad.com']);
+    expect(settings.whitelistedTabGroups).toEqual(['Important']);
+  });
 });
 
 describe('saveSettings error handling', () => {
   beforeEach(() => {
     chromeMock.storage.sync.get.mockReset();
     chromeMock.storage.sync.set.mockReset();
+    chromeMock.storage.local.get.mockReset();
+    chromeMock.storage.local.set.mockReset();
   });
 
-  it('should handle storage error gracefully', async () => {
-    // Suppress console.error output during this test
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  it('should propagate storage errors', async () => {
     chromeMock.storage.sync.set.mockRejectedValue(new Error('Storage error'));
 
-    // Should not throw
-    await saveSettings({ enabled: true });
-
-    // Should log error (console.error is called)
-    // In happy-dom, console.error is mocked by vitest
-    consoleErrorSpy.mockRestore();
+    await expect(saveSettings({ enabled: true })).rejects.toThrow('Storage error');
   });
 
-  it('should handle different storage error types', async () => {
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  it('should propagate quota exceeded errors', async () => {
     chromeMock.storage.sync.set.mockRejectedValue(new Error('QuotaExceededError'));
 
-    await saveSettings({ maxTabs: 200 });
+    await expect(saveSettings({ maxTabs: 200 })).rejects.toThrow('QuotaExceededError');
+  });
 
-    expect(consoleErrorSpy).toHaveBeenCalled();
-    consoleErrorSpy.mockRestore();
+  it('should propagate local storage errors', async () => {
+    chromeMock.storage.local.set.mockRejectedValue(new Error('Local storage error'));
+
+    await expect(saveSettings({ whitelist: ['test.com'] })).rejects.toThrow('Local storage error');
   });
 
   it('should handle invalid settings object', async () => {
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     chromeMock.storage.sync.set.mockResolvedValue(undefined);
 
     await saveSettings({ invalidKey: 'value' } as Parameters<typeof saveSettings>[0]);
 
-    // Should attempt to save (Chrome storage ignores unknown keys)
     expect(chromeMock.storage.sync.set).toHaveBeenCalled();
-    consoleErrorSpy.mockRestore();
   });
 });
 
@@ -148,10 +166,13 @@ describe('saveSettings', () => {
   beforeEach(() => {
     chromeMock.storage.sync.get.mockReset();
     chromeMock.storage.sync.set.mockReset();
+    chromeMock.storage.local.get.mockReset();
+    chromeMock.storage.local.set.mockReset();
   });
 
-  it('should save partial settings to storage', async () => {
+  it('should save scalar settings to sync storage', async () => {
     chromeMock.storage.sync.set.mockResolvedValue(undefined);
+    chromeMock.storage.local.set.mockResolvedValue(undefined);
 
     await saveSettings({ enabled: true, maxTabs: 100 });
 
@@ -159,6 +180,7 @@ describe('saveSettings', () => {
       enabled: true,
       maxTabs: 100,
     });
+    expect(chromeMock.storage.local.set).not.toHaveBeenCalled();
   });
 
   it('should save single setting', async () => {
@@ -171,30 +193,52 @@ describe('saveSettings', () => {
     });
   });
 
-  it('should handle storage error gracefully', async () => {
-    // Suppress console.error output during this test
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    chromeMock.storage.sync.set.mockRejectedValue(new Error('Storage error'));
-
-    // Should not throw
-    await saveSettings({ enabled: true });
-
-    // Should log error (console.error is called)
-    // In happy-dom, console.error is mocked by vitest
-    consoleErrorSpy.mockRestore();
-  });
-
-  it('should save array settings', async () => {
+  it('should save domain lists to local storage', async () => {
     chromeMock.storage.sync.set.mockResolvedValue(undefined);
+    chromeMock.storage.local.set.mockResolvedValue(undefined);
 
     await saveSettings({
       whitelist: ['a.com', 'b.com'],
       blacklist: ['c.com'],
     });
 
-    expect(chromeMock.storage.sync.set).toHaveBeenCalledWith({
+    expect(chromeMock.storage.sync.set).not.toHaveBeenCalled();
+    expect(chromeMock.storage.local.set).toHaveBeenCalledWith({
       whitelist: ['a.com', 'b.com'],
       blacklist: ['c.com'],
+    });
+  });
+
+  it('should save whitelistedTabGroups to local storage', async () => {
+    chromeMock.storage.sync.set.mockResolvedValue(undefined);
+    chromeMock.storage.local.set.mockResolvedValue(undefined);
+
+    await saveSettings({
+      whitelistedTabGroups: ['Work', 'Personal'],
+    });
+
+    expect(chromeMock.storage.sync.set).not.toHaveBeenCalled();
+    expect(chromeMock.storage.local.set).toHaveBeenCalledWith({
+      whitelistedTabGroups: ['Work', 'Personal'],
+    });
+  });
+
+  it('should split mixed settings across both backends', async () => {
+    chromeMock.storage.sync.set.mockResolvedValue(undefined);
+    chromeMock.storage.local.set.mockResolvedValue(undefined);
+
+    await saveSettings({
+      enabled: true,
+      whitelist: ['test.com'],
+      theme: 'dark',
+    });
+
+    expect(chromeMock.storage.sync.set).toHaveBeenCalledWith({
+      enabled: true,
+      theme: 'dark',
+    });
+    expect(chromeMock.storage.local.set).toHaveBeenCalledWith({
+      whitelist: ['test.com'],
     });
   });
 

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -1,15 +1,26 @@
 /**
  * Minimal storage abstraction for settings persistence.
- * Default implementation uses chrome.storage.sync; can be swapped for testing.
+ * Default implementation uses chrome.storage.sync/local; can be swapped for testing.
  */
 export interface SettingsStorage {
   get(keys: string[]): Promise<Record<string, unknown>>;
   set(items: Record<string, unknown>): Promise<void>;
 }
 
-const defaultStorage: SettingsStorage = {
+/** Storage keys that go to chrome.storage.sync (small, scalar values) */
+const SYNC_KEYS = new Set(['enabled', 'idleTimeout', 'maxTabs', 'notificationsEnabled', 'theme']);
+
+/** Storage keys that go to chrome.storage.local (large lists that can exceed sync quota) */
+const LOCAL_KEYS = new Set(['whitelist', 'blacklist', 'whitelistedTabGroups']);
+
+const defaultSyncStorage: SettingsStorage = {
   get: (keys) => chrome.storage.sync.get(keys),
   set: (items) => chrome.storage.sync.set(items),
+};
+
+const defaultLocalStorage: SettingsStorage = {
+  get: (keys) => chrome.storage.local.get(keys),
+  set: (items) => chrome.storage.local.set(items),
 };
 
 /**
@@ -49,14 +60,24 @@ export const DEFAULT_SETTINGS: Settings = {
 /**
  * Retrieves user settings from storage.
  * Merges stored settings with defaults for missing values.
- * @param storage - Storage backend (defaults to chrome.storage.sync)
+ * Reads from both sync and local storage backends.
+ * @param syncStore - Sync storage backend (defaults to chrome.storage.sync)
+ * @param localStore - Local storage backend (defaults to chrome.storage.local)
  * @returns Promise resolving to current settings
  */
-export async function getSettings(storage?: SettingsStorage): Promise<Settings> {
-  const store = storage ?? defaultStorage;
+export async function getSettings(
+  syncStore?: SettingsStorage,
+  localStore?: SettingsStorage,
+): Promise<Settings> {
+  const sync = syncStore ?? defaultSyncStorage;
+  const local = localStore ?? defaultLocalStorage;
+
   try {
-    const result = await store.get(Object.keys(DEFAULT_SETTINGS));
-    return { ...DEFAULT_SETTINGS, ...result };
+    const [syncResult, localResult] = await Promise.all([
+      sync.get([...SYNC_KEYS]),
+      local.get([...LOCAL_KEYS]),
+    ]);
+    return { ...DEFAULT_SETTINGS, ...syncResult, ...localResult };
   } catch (error) {
     console.error('Error getting settings:', error);
     return DEFAULT_SETTINGS;
@@ -65,19 +86,34 @@ export async function getSettings(storage?: SettingsStorage): Promise<Settings> 
 
 /**
  * Saves partial settings to storage.
- * Only updates specified fields, leaves others unchanged.
+ * Routes each key to the appropriate backend (sync for scalars, local for lists).
  * @param settings - Partial settings object to save
- * @param storage - Storage backend (defaults to chrome.storage.sync)
+ * @param syncStore - Sync storage backend (defaults to chrome.storage.sync)
+ * @param localStore - Local storage backend (defaults to chrome.storage.local)
  * @returns Promise resolving when complete
+ * @throws Error if storage write fails
  */
 export async function saveSettings(
   settings: Partial<Settings>,
-  storage?: SettingsStorage,
+  syncStore?: SettingsStorage,
+  localStore?: SettingsStorage,
 ): Promise<void> {
-  const store = storage ?? defaultStorage;
-  try {
-    await store.set(settings);
-  } catch (error) {
-    console.error('Error saving settings:', error);
+  const sync = syncStore ?? defaultSyncStorage;
+  const local = localStore ?? defaultLocalStorage;
+
+  const syncItems: Record<string, unknown> = {};
+  const localItems: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(settings)) {
+    if (LOCAL_KEYS.has(key)) {
+      localItems[key] = value;
+    } else {
+      syncItems[key] = value;
+    }
   }
+
+  await Promise.all([
+    Object.keys(syncItems).length > 0 ? sync.set(syncItems) : Promise.resolve(),
+    Object.keys(localItems).length > 0 ? local.set(localItems) : Promise.resolve(),
+  ]);
 }


### PR DESCRIPTION
Closes #29

## Problem

Chrome's storage.sync has strict quotas:
- Max total: 102,400 bytes (100 KB)
- Max per item: 8,192 bytes (8 KB)
- Max items: 512

Domain lists (whitelist, blacklist, whitelistedTabGroups) can easily exceed these limits. A user with 100+ domains would hit the 8KB per-item limit, and saveSettings() silently swallowed the QuotaExceededError.

## Solution

Split storage into two backends:
- storage.sync: Scalar settings (enabled, idleTimeout, maxTabs, notificationsEnabled, theme)
- storage.local: Large domain lists (whitelist, blacklist, whitelistedTabGroups) — 8MB quota

## Changes

- src/shared/settings.ts: Split getSettings() and saveSettings() to route keys to appropriate backends
- src/shared/settings.ts: saveSettings() now throws on failure instead of silently swallowing errors
- src/options/options.ts: Shows specific error messages when save fails
- src/background/index.ts: Listens for storage.local changes to re-apply cleanup rules
- src/shared/settings.test.ts: Updated tests for dual-backend storage logic

## Testing

- All 287 tests pass
- Lint passes for changed files
- Format passes
