### PR TITLE
feat: persist tabActivityMap to survive MV3 service worker restarts

### DIFF
--- a/src/background/index.test.ts
+++ b/src/background/index.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type { MockChrome } from '../__test-utils__/chrome-mock';
 import '../shared/__mocks__/chrome';
 const chromeMock = chrome as unknown as MockChrome;
@@ -14,6 +14,7 @@ import {
   initializeActivityTracking,
   handleStorageChanged,
   handleCommand,
+  loadTabActivityMap,
 } from './index';
 import { getDomain, domainMatches } from '../shared/domain';
 
@@ -2146,6 +2147,190 @@ describe('chrome.commands.onCommand listener', () => {
     // Should not throw — errors are caught
     await vi.waitFor(() => {
       expect(chromeMock.tabs.query).toHaveBeenCalled();
+    });
+  });
+});
+
+describe('tabActivityMap persistence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetTabActivityMap();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('loadTabActivityMap', () => {
+    it('should return empty map when nothing stored', async () => {
+      chromeMock.storage.local.get.mockResolvedValue({});
+      const loaded = await loadTabActivityMap();
+      expect(loaded.size).toBe(0);
+    });
+
+    it('should restore stored activity map', async () => {
+      chromeMock.storage.local.get.mockResolvedValue({
+        tabActivityMap: { '1': 1000, '2': 2000 },
+      });
+      const loaded = await loadTabActivityMap();
+      expect(loaded.size).toBe(2);
+      expect(loaded.get(1)).toBe(1000);
+      expect(loaded.get(2)).toBe(2000);
+    });
+
+    it('should handle invalid data gracefully', async () => {
+      chromeMock.storage.local.get.mockResolvedValue({
+        tabActivityMap: 'invalid',
+      });
+      const loaded = await loadTabActivityMap();
+      expect(loaded.size).toBe(0);
+    });
+
+    it('should filter out NaN keys', async () => {
+      chromeMock.storage.local.get.mockResolvedValue({
+        tabActivityMap: { abc: 1000, '1': 2000 },
+      });
+      const loaded = await loadTabActivityMap();
+      expect(loaded.size).toBe(1);
+      expect(loaded.get(1)).toBe(2000);
+    });
+
+    it('should handle Chrome API errors', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      chromeMock.storage.local.get.mockRejectedValue(new Error('Storage error'));
+      const loaded = await loadTabActivityMap();
+      expect(loaded.size).toBe(0);
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe('schedulePersistTabActivityMap', () => {
+    it('should persist after debounce delay', async () => {
+      updateTabActivity(1);
+      updateTabActivity(2);
+
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(chromeMock.storage.local.set).toHaveBeenCalledWith({
+        tabActivityMap: { '1': expect.any(Number), '2': expect.any(Number) },
+      });
+    });
+
+    it('should debounce multiple rapid calls', async () => {
+      updateTabActivity(1);
+      await vi.advanceTimersByTimeAsync(100);
+      updateTabActivity(2);
+      await vi.advanceTimersByTimeAsync(100);
+      updateTabActivity(3);
+
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(chromeMock.storage.local.set).toHaveBeenCalledTimes(1);
+    });
+
+    it('should persist after removeTabActivity', async () => {
+      updateTabActivity(1);
+      await vi.advanceTimersByTimeAsync(500);
+
+      removeTabActivity(1);
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(chromeMock.storage.local.set).toHaveBeenLastCalledWith({
+        tabActivityMap: {},
+      });
+    });
+
+    it('should handle storage errors gracefully', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      chromeMock.storage.local.set.mockRejectedValue(new Error('Storage error'));
+
+      updateTabActivity(1);
+      await vi.advanceTimersByTimeAsync(500);
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe('initializeActivityTracking with persistence', () => {
+    it('should restore from storage and seed missing tabs', async () => {
+      chromeMock.storage.local.get.mockResolvedValue({
+        tabActivityMap: { '1': 1000, '999': 2000 },
+      });
+      chromeMock.tabs.query.mockResolvedValue([
+        { id: 1, url: 'https://a.com', lastAccessed: 5000 },
+        { id: 2, url: 'https://b.com', lastAccessed: 6000 },
+      ]);
+
+      await initializeActivityTracking();
+
+      expect(
+        getLastActivity({
+          id: 1,
+          url: '',
+          title: '',
+          index: 0,
+          pinned: false,
+          highlighted: false,
+          active: false,
+          windowId: 1,
+          incognito: false,
+          selected: false,
+          discarded: false,
+          autoDiscardable: true,
+          groupId: -1,
+        } as chrome.tabs.Tab),
+      ).toBe(1000);
+
+      expect(
+        getLastActivity({
+          id: 2,
+          url: '',
+          title: '',
+          index: 0,
+          pinned: false,
+          highlighted: false,
+          active: false,
+          windowId: 1,
+          incognito: false,
+          selected: false,
+          discarded: false,
+          autoDiscardable: true,
+          groupId: -1,
+        } as chrome.tabs.Tab),
+      ).toBe(6000);
+    });
+
+    it('should remove stale entries for closed tabs', async () => {
+      updateTabActivity(1);
+      updateTabActivity(999);
+      await vi.advanceTimersByTimeAsync(500);
+
+      chromeMock.storage.local.get.mockResolvedValue({});
+      chromeMock.tabs.query.mockResolvedValue([
+        { id: 1, url: 'https://a.com', lastAccessed: 5000 },
+      ]);
+
+      resetTabActivityMap();
+      await initializeActivityTracking();
+
+      expect(
+        getLastActivity({
+          id: 999,
+          url: '',
+          title: '',
+          index: 0,
+          pinned: false,
+          highlighted: false,
+          active: false,
+          windowId: 1,
+          incognito: false,
+          selected: false,
+          discarded: false,
+          autoDiscardable: true,
+          groupId: -1,
+        } as chrome.tabs.Tab),
+      ).toBe(0);
     });
   });
 });

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -4,6 +4,58 @@ import { computeCleanup } from './cleanup';
 // Store last activity timestamps for each tab (tabId -> timestamp)
 const tabActivityMap: Map<number, number> = new Map();
 
+// Debounce timer for persisting tabActivityMap
+let persistTimer: ReturnType<typeof setTimeout> | null = null;
+
+// Storage key for tab activity map
+const TAB_ACTIVITY_KEY = 'tabActivityMap';
+
+/**
+ * Persists the tabActivityMap to chrome.storage.local.
+ * Uses debouncing to avoid excessive writes.
+ */
+export function schedulePersistTabActivityMap(): void {
+  if (persistTimer !== null) {
+    clearTimeout(persistTimer);
+  }
+  persistTimer = setTimeout(() => {
+    persistTimer = null;
+    const obj: Record<string, number> = {};
+    tabActivityMap.forEach((value, key) => {
+      obj[key.toString()] = value;
+    });
+    chrome.storage.local.set({ [TAB_ACTIVITY_KEY]: obj }).catch((err) => {
+      console.error('Error persisting tabActivityMap:', err);
+    });
+  }, 500);
+}
+
+/**
+ * Loads the tabActivityMap from chrome.storage.local.
+ * Returns a Map of tabId -> timestamp, or an empty Map if nothing stored.
+ */
+export async function loadTabActivityMap(): Promise<Map<number, number>> {
+  try {
+    const stored = (await chrome.storage.local.get(TAB_ACTIVITY_KEY)) as {
+      [TAB_ACTIVITY_KEY]?: Record<string, number>;
+    };
+    const raw = stored[TAB_ACTIVITY_KEY];
+    if (raw && typeof raw === 'object') {
+      const restored = new Map<number, number>();
+      for (const [key, value] of Object.entries(raw)) {
+        const numKey = Number(key);
+        if (!isNaN(numKey) && typeof value === 'number') {
+          restored.set(numKey, value);
+        }
+      }
+      return restored;
+    }
+  } catch (err) {
+    console.error('Error loading tabActivityMap:', err);
+  }
+  return new Map();
+}
+
 /**
  * Clears all tab activity records.
  * Used for testing purposes to reset state between tests.
@@ -19,6 +71,7 @@ export function resetTabActivityMap(): void {
  */
 export function updateTabActivity(tabId: number): void {
   tabActivityMap.set(tabId, Date.now());
+  schedulePersistTabActivityMap();
 }
 
 /**
@@ -40,6 +93,7 @@ export function getLastActivity(tab: chrome.tabs.Tab): number {
  */
 export function removeTabActivity(tabId: number): void {
   tabActivityMap.delete(tabId);
+  schedulePersistTabActivityMap();
 }
 
 // Set warning icon (yellow when warning is active)
@@ -68,14 +122,32 @@ export async function setWarningIcon(enable: boolean): Promise<void> {
 // Initialize activity tracking for all existing tabs on startup
 export async function initializeActivityTracking(): Promise<void> {
   try {
+    const restored = await loadTabActivityMap();
+    tabActivityMap.clear();
+    restored.forEach((value, key) => tabActivityMap.set(key, value));
+
     const tabs = await chrome.tabs.query({});
     const now = Date.now();
+    const currentTabIds = new Set<number>();
     tabs.forEach((tab) => {
       if (tab.id) {
-        // Use existing lastAccessed or current time
-        tabActivityMap.set(tab.id, tab.lastAccessed || now);
+        currentTabIds.add(tab.id);
+        if (!tabActivityMap.has(tab.id)) {
+          tabActivityMap.set(tab.id, tab.lastAccessed || now);
+        }
       }
     });
+
+    let staleRemoved = 0;
+    tabActivityMap.forEach((_, key) => {
+      if (!currentTabIds.has(key)) {
+        tabActivityMap.delete(key);
+        staleRemoved++;
+      }
+    });
+    if (staleRemoved > 0) {
+      schedulePersistTabActivityMap();
+    }
   } catch (error) {
     console.error('Error initializing activity tracking:', error);
   }


### PR DESCRIPTION
## Summary

Persist tabActivityMap to chrome.storage.local to survive MV3 service worker restarts.

## Changes

- Added schedulePersistTabActivityMap() function with 500ms debounce to persist the map
- Added loadTabActivityMap() function to restore the map from storage
- Modified updateTabActivity() to trigger persistence after updating the map
- Modified removeTabActivity() to trigger persistence after deleting from the map
- Modified initializeActivityTracking() to:
  1. Restore from storage before reseeding
  2. Clean up stale entries for tabs that no longer exist
- Added comprehensive tests for persistence functionality

## Testing

- All existing tests pass
- Added new tests for persistence, load, and stale entry cleanup
- Production build succeeds
- Lint and format checks pass

Closes #32
