### PR TITLE
refactor: convert deprecated callback Chrome API calls to native MV3 Promise API

### DIFF
--- a/src/background/index.test.ts
+++ b/src/background/index.test.ts
@@ -918,6 +918,24 @@ describe('applyCleanupRules', () => {
     await expect(applyCleanupRules()).resolves.not.toThrow();
   });
 
+  it('should handle warning notification creation error gracefully', async () => {
+    chromeMock.storage.sync.get.mockResolvedValue({
+      enabled: true,
+      idleTimeout: 60,
+      maxTabs: 1,
+      whitelist: [],
+      blacklist: [],
+      notificationsEnabled: true,
+    });
+    chromeMock.tabs.query.mockResolvedValue([
+      createTab({ id: 1, url: 'https://a.com', active: true, lastAccessed: 100 }),
+      createTab({ id: 2, url: 'https://b.com', lastAccessed: 200 }),
+    ]);
+    chromeMock.notifications.create.mockRejectedValue(new Error('Warning notification error'));
+
+    await expect(applyCleanupRules()).resolves.not.toThrow();
+  });
+
   it('should handle tabs at various idle times correctly', async () => {
     const now = Date.now();
     chromeMock.storage.sync.get.mockResolvedValue({

--- a/src/background/index.test.ts
+++ b/src/background/index.test.ts
@@ -952,51 +952,39 @@ describe('setWarningIcon', () => {
   it('should set yellow warning icon when enabled', async () => {
     const getURLSpy = chromeMock.runtime.getURL;
     getURLSpy.mockImplementation((path: any): string => `chrome-extension://mock/${path}`);
-    chromeMock.action.setIcon.mockImplementation((_: any, callback: any) => {
-      if (callback) callback();
-      return Promise.resolve();
-    });
+    chromeMock.action.setIcon.mockResolvedValue(undefined);
 
     await setWarningIcon(true);
 
     expect(getURLSpy).toHaveBeenCalledWith('icons/icon16-yellow.png');
     expect(getURLSpy).toHaveBeenCalledWith('icons/icon48-yellow.png');
     expect(getURLSpy).toHaveBeenCalledWith('icons/icon128-yellow.png');
-    expect(chromeMock.action.setIcon).toHaveBeenCalledWith(
-      {
-        path: {
-          16: 'chrome-extension://mock/icons/icon16-yellow.png',
-          48: 'chrome-extension://mock/icons/icon48-yellow.png',
-          128: 'chrome-extension://mock/icons/icon128-yellow.png',
-        },
+    expect(chromeMock.action.setIcon).toHaveBeenCalledWith({
+      path: {
+        16: 'chrome-extension://mock/icons/icon16-yellow.png',
+        48: 'chrome-extension://mock/icons/icon48-yellow.png',
+        128: 'chrome-extension://mock/icons/icon128-yellow.png',
       },
-      expect.any(Function),
-    );
+    });
   });
 
   it('should set normal icon when disabled', async () => {
     const getURLSpy = chromeMock.runtime.getURL;
     getURLSpy.mockImplementation((path: any): string => `chrome-extension://mock/${path}`);
-    chromeMock.action.setIcon.mockImplementation((_: any, callback: any) => {
-      if (callback) callback();
-      return Promise.resolve();
-    });
+    chromeMock.action.setIcon.mockResolvedValue(undefined);
 
     await setWarningIcon(false);
 
     expect(getURLSpy).toHaveBeenCalledWith('icons/icon16.png');
     expect(getURLSpy).toHaveBeenCalledWith('icons/icon48.png');
     expect(getURLSpy).toHaveBeenCalledWith('icons/icon128.png');
-    expect(chromeMock.action.setIcon).toHaveBeenCalledWith(
-      {
-        path: {
-          16: 'chrome-extension://mock/icons/icon16.png',
-          48: 'chrome-extension://mock/icons/icon48.png',
-          128: 'chrome-extension://mock/icons/icon128.png',
-        },
+    expect(chromeMock.action.setIcon).toHaveBeenCalledWith({
+      path: {
+        16: 'chrome-extension://mock/icons/icon16.png',
+        48: 'chrome-extension://mock/icons/icon48.png',
+        128: 'chrome-extension://mock/icons/icon128.png',
       },
-      expect.any(Function),
-    );
+    });
   });
 
   it('should handle Chrome API errors gracefully', async () => {
@@ -1005,16 +993,7 @@ describe('setWarningIcon', () => {
 
     const getURLSpy = chromeMock.runtime.getURL;
     getURLSpy.mockImplementation((path: any): string => `chrome-extension://mock/${path}`);
-    chromeMock.action.setIcon.mockImplementation((_: any, callback: any) => {
-      if (callback) {
-        callback();
-        Object.defineProperty(chrome.runtime, 'lastError', {
-          value: { message: 'Icon error' },
-          writable: true,
-        });
-      }
-      return Promise.resolve();
-    });
+    chromeMock.action.setIcon.mockRejectedValue(new Error('Icon error'));
 
     await setWarningIcon(true);
 

--- a/src/background/index.test.ts
+++ b/src/background/index.test.ts
@@ -919,10 +919,13 @@ describe('applyCleanupRules', () => {
   });
 
   it('should handle warning notification creation error gracefully', async () => {
+    handleStorageChanged({ enabled: { newValue: true, oldValue: true } }, 'sync');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
     chromeMock.storage.sync.get.mockResolvedValue({
       enabled: true,
       idleTimeout: 60,
-      maxTabs: 1,
+      maxTabs: 5,
       whitelist: [],
       blacklist: [],
       notificationsEnabled: true,
@@ -930,6 +933,8 @@ describe('applyCleanupRules', () => {
     chromeMock.tabs.query.mockResolvedValue([
       createTab({ id: 1, url: 'https://a.com', active: true, lastAccessed: 100 }),
       createTab({ id: 2, url: 'https://b.com', lastAccessed: 200 }),
+      createTab({ id: 3, url: 'https://c.com', lastAccessed: 300 }),
+      createTab({ id: 4, url: 'https://d.com', lastAccessed: 400 }),
     ]);
     chromeMock.notifications.create.mockRejectedValue(new Error('Warning notification error'));
 

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -109,14 +109,11 @@ export async function setWarningIcon(enable: boolean): Promise<void> {
         48: chrome.runtime.getURL('icons/icon48.png'),
         128: chrome.runtime.getURL('icons/icon128.png'),
       };
-  await new Promise<void>((resolve) => {
-    chrome.action.setIcon({ path: iconPath }, () => {
-      if (chrome.runtime.lastError) {
-        console.warn('setIcon error:', chrome.runtime.lastError.message);
-      }
-      resolve();
-    });
-  });
+  try {
+    await chrome.action.setIcon({ path: iconPath });
+  } catch (err) {
+    console.warn('setIcon error:', err);
+  }
 }
 
 // Initialize activity tracking for all existing tabs on startup
@@ -207,19 +204,16 @@ export async function applyCleanupRules() {
         warningActive = true;
         await setWarningIcon(true);
         if (notificationsEnabled) {
-          chrome.notifications.create(
-            {
+          try {
+            await chrome.notifications.create({
               type: 'basic',
               iconUrl: chrome.runtime.getURL('icons/icon128.png'),
               title: 'Tab Warning',
               message: `You have ${result.tabCount} tabs open (limit: ${maxTabs}). Consider closing some tabs.`,
-            },
-            () => {
-              if (chrome.runtime.lastError) {
-                console.warn('Notification error:', chrome.runtime.lastError.message);
-              }
-            },
-          );
+            });
+          } catch (err) {
+            console.warn('Notification error:', err);
+          }
         }
       }
     } else if (warningActive) {
@@ -245,19 +239,16 @@ export async function applyCleanupRules() {
       });
 
       if (notificationsEnabled) {
-        chrome.notifications.create(
-          {
+        try {
+          await chrome.notifications.create({
             type: 'basic',
             iconUrl: chrome.runtime.getURL('icons/icon128.png'),
             title: 'Tabs Cleaned',
             message: `Automatically closed ${result.tabIdsToClose.length} inactive tab(s).`,
-          },
-          () => {
-            if (chrome.runtime.lastError) {
-              console.warn('Notification error:', chrome.runtime.lastError.message);
-            }
-          },
-        );
+          });
+        } catch (err) {
+          console.warn('Notification error:', err);
+        }
       }
     }
   } catch (error) {


### PR DESCRIPTION
Closes #33

## Summary

Convert deprecated MV2-style callback Chrome API calls to native MV3 Promise API.

## Changes

- setWarningIcon: Removed unnecessary Promise wrapper around chrome.action.setIcon() - now uses direct await with try-catch
- chrome.notifications.create: Converted 2 callback-based calls to Promise API with try-catch error handling
- Tests: Updated test mocks to use Promise-based API instead of callback pattern

## Impact

- Simplifies production code by removing callback boilerplate
- Tests now match the actual MV3 Promise API behavior
- No more chrome.runtime.lastError checks (Promises reject with errors directly)