### PR TITLE
fix: include tabActivityMap in export-import

### DIFF
--- a/src/options/options.test.ts
+++ b/src/options/options.test.ts
@@ -994,6 +994,279 @@ describe('bindEventListeners', () => {
     expect(global.alert).toHaveBeenCalledWith('Settings restored successfully!');
   });
 
+  it('should include tabActivityMap in backup export', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const mockForm = {
+      addEventListener: vi.fn(),
+    } as unknown as HTMLFormElement;
+    const mockInput = {
+      value: '',
+      checked: false,
+      addEventListener: vi.fn(),
+    } as unknown as HTMLInputElement;
+    const mockSelect = {
+      value: '',
+      addEventListener: vi.fn(),
+    } as unknown as HTMLSelectElement;
+    const mockTextarea = {
+      value: '',
+      addEventListener: vi.fn(),
+    } as unknown as HTMLTextAreaElement;
+    const mockButton = {
+      addEventListener: vi.fn(),
+    } as unknown as HTMLButtonElement;
+
+    mockGetElementById.mockImplementation((id) => {
+      const elements: Record<string, Element> = {
+        'options-form': mockForm,
+        'idle-timeout': mockInput,
+        'max-tabs': mockInput,
+        theme: mockSelect,
+        whitelist: mockTextarea,
+        blacklist: mockTextarea,
+        'whitelisted-tab-groups': mockTextarea,
+        'notifications-enabled': mockInput,
+        'backup-btn': mockButton,
+        'restore-btn': mockButton,
+        'restore-file': mockInput,
+      };
+      return elements[id] || null;
+    });
+    mockMatchMedia.mockReturnValue({
+      matches: false,
+      media: '',
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    });
+    // getSettings() reads from sync (for sync keys) and local (for local list keys)
+    chromeMock.storage.sync.get.mockResolvedValue({ ...DEFAULT_SETTINGS });
+    // First call: getSettings() reads local storage for whitelist/blacklist/whitelistedTabGroups
+    chromeMock.storage.local.get.mockResolvedValueOnce({
+      whitelist: [],
+      blacklist: [],
+      whitelistedTabGroups: [],
+    });
+    // Second call: export handler reads local storage for tabsCleanedToday/tabsCleanedDate/tabActivityMap
+    chromeMock.storage.local.get.mockResolvedValueOnce({
+      tabsCleanedToday: 5,
+      tabsCleanedDate: '2025-01-15',
+      tabActivityMap: { '1': 1705300000000, '2': 1705300001000 },
+    });
+
+    const elements = getFormElements();
+    if (elements) {
+      bindEventListeners(elements);
+      const backupCall = (
+        mockButton.addEventListener as unknown as ReturnType<typeof vi.fn>
+      ).mock.calls.find((call: unknown) => (call as unknown[])[0] === 'click');
+      if (backupCall) {
+        const backupHandler = backupCall[1];
+        await backupHandler();
+      }
+    }
+
+    // Verify chrome.storage.local.get was called with tabActivityMap
+    expect(chromeMock.storage.local.get).toHaveBeenCalledWith([
+      'tabsCleanedToday',
+      'tabsCleanedDate',
+      'tabActivityMap',
+    ]);
+
+    // Verify Blob was created with tabActivityMap in the export data
+    expect(global.Blob).toHaveBeenCalledWith(
+      [
+        JSON.stringify(
+          {
+            settings: DEFAULT_SETTINGS,
+            tabsCleanedToday: 5,
+            tabsCleanedDate: '2025-01-15',
+            tabActivityMap: { '1': 1705300000000, '2': 1705300001000 },
+          },
+          null,
+          2,
+        ),
+      ],
+      { type: 'application/json' },
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('should restore tabActivityMap from new-format backup on import', async () => {
+    const mockForm = {
+      addEventListener: vi.fn(),
+    } as unknown as HTMLFormElement;
+    const mockInput = {
+      value: '',
+      checked: false,
+      addEventListener: vi.fn(),
+    } as unknown as HTMLInputElement;
+    const mockSelect = {
+      value: '',
+      addEventListener: vi.fn(),
+    } as unknown as HTMLSelectElement;
+    const mockTextarea = {
+      value: '',
+      addEventListener: vi.fn(),
+    } as unknown as HTMLTextAreaElement;
+    const mockButton = {
+      addEventListener: vi.fn(),
+    } as unknown as HTMLButtonElement;
+
+    mockGetElementById.mockImplementation((id) => {
+      const elements: Record<string, Element> = {
+        'options-form': mockForm,
+        'idle-timeout': mockInput,
+        'max-tabs': mockInput,
+        theme: mockSelect,
+        whitelist: mockTextarea,
+        blacklist: mockTextarea,
+        'whitelisted-tab-groups': mockTextarea,
+        'notifications-enabled': mockInput,
+        'backup-btn': mockButton,
+        'restore-btn': mockButton,
+        'restore-file': mockInput,
+      };
+      return elements[id] || null;
+    });
+    mockMatchMedia.mockReturnValue({
+      matches: false,
+      media: '',
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    });
+
+    const newFormatBackup = JSON.stringify({
+      settings: { idleTimeout: 45 },
+      tabsCleanedToday: 10,
+      tabsCleanedDate: '2025-01-20',
+      tabActivityMap: { '100': 1705400000000, '200': 1705400005000 },
+    });
+
+    const elements = getFormElements();
+    if (elements) {
+      bindEventListeners(elements);
+      const changeCall = (
+        mockInput.addEventListener as unknown as ReturnType<typeof vi.fn>
+      ).mock.calls.find((call: unknown) => (call as unknown[])[0] === 'change');
+      if (changeCall) {
+        const changeHandler = changeCall[1];
+        const mockEvent = {
+          target: {
+            files: [
+              {
+                text: vi.fn().mockResolvedValue(newFormatBackup),
+              },
+            ],
+          },
+        };
+        await changeHandler(mockEvent);
+      }
+    }
+
+    // Verify tabActivityMap was restored to local storage
+    expect(chromeMock.storage.local.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tabActivityMap: { '100': 1705400000000, '200': 1705400005000 },
+      }),
+    );
+    expect(global.alert).toHaveBeenCalledWith('Settings restored successfully!');
+  });
+
+  it('should default tabActivityMap to empty object when missing from old-format backup', async () => {
+    const mockForm = {
+      addEventListener: vi.fn(),
+    } as unknown as HTMLFormElement;
+    const mockInput = {
+      value: '',
+      checked: false,
+      addEventListener: vi.fn(),
+    } as unknown as HTMLInputElement;
+    const mockSelect = {
+      value: '',
+      addEventListener: vi.fn(),
+    } as unknown as HTMLSelectElement;
+    const mockTextarea = {
+      value: '',
+      addEventListener: vi.fn(),
+    } as unknown as HTMLTextAreaElement;
+    const mockButton = {
+      addEventListener: vi.fn(),
+    } as unknown as HTMLButtonElement;
+
+    mockGetElementById.mockImplementation((id) => {
+      const elements: Record<string, Element> = {
+        'options-form': mockForm,
+        'idle-timeout': mockInput,
+        'max-tabs': mockInput,
+        theme: mockSelect,
+        whitelist: mockTextarea,
+        blacklist: mockTextarea,
+        'whitelisted-tab-groups': mockTextarea,
+        'notifications-enabled': mockInput,
+        'backup-btn': mockButton,
+        'restore-btn': mockButton,
+        'restore-file': mockInput,
+      };
+      return elements[id] || null;
+    });
+    mockMatchMedia.mockReturnValue({
+      matches: false,
+      media: '',
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    });
+
+    // Old-format backup: no tabActivityMap field
+    const oldFormatBackup = JSON.stringify({
+      settings: { idleTimeout: 45 },
+      tabsCleanedToday: 3,
+      tabsCleanedDate: '2025-01-10',
+    });
+
+    const elements = getFormElements();
+    if (elements) {
+      bindEventListeners(elements);
+      const changeCall = (
+        mockInput.addEventListener as unknown as ReturnType<typeof vi.fn>
+      ).mock.calls.find((call: unknown) => (call as unknown[])[0] === 'change');
+      if (changeCall) {
+        const changeHandler = changeCall[1];
+        const mockEvent = {
+          target: {
+            files: [
+              {
+                text: vi.fn().mockResolvedValue(oldFormatBackup),
+              },
+            ],
+          },
+        };
+        await changeHandler(mockEvent);
+      }
+    }
+
+    // Verify tabActivityMap defaults to {} when missing
+    expect(chromeMock.storage.local.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tabActivityMap: {},
+      }),
+    );
+    expect(global.alert).toHaveBeenCalledWith('Settings restored successfully!');
+  });
+
   it('should listen for system theme changes', async () => {
     const mockForm = {
       addEventListener: vi.fn(),

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -179,11 +179,17 @@ export function bindEventListeners(elements: OptionsFormElements): void {
       const localData = (await chrome.storage.local.get([
         'tabsCleanedToday',
         'tabsCleanedDate',
-      ])) as { tabsCleanedToday?: number; tabsCleanedDate?: string };
+        'tabActivityMap',
+      ])) as {
+        tabsCleanedToday?: number;
+        tabsCleanedDate?: string;
+        tabActivityMap?: Record<string, number>;
+      };
       const exportData = {
         settings,
         tabsCleanedToday: localData.tabsCleanedToday ?? 0,
         tabsCleanedDate: localData.tabsCleanedDate ?? new Date().toISOString().split('T')[0],
+        tabActivityMap: localData.tabActivityMap ?? {},
       };
       const blob = new Blob([JSON.stringify(exportData, null, 2)], {
         type: 'application/json',
@@ -237,15 +243,17 @@ export function bindEventListeners(elements: OptionsFormElements): void {
 
       await saveSettings(fullSettings);
 
-      // Restore local storage data (tabsCleanedToday, tabsCleanedDate)
+      // Restore local storage data (tabsCleanedToday, tabsCleanedDate, tabActivityMap)
       if (isNewFormat) {
         const exportData = rawParsed as {
           tabsCleanedToday?: number;
           tabsCleanedDate?: string;
+          tabActivityMap?: Record<string, number>;
         };
         await chrome.storage.local.set({
           tabsCleanedToday: exportData.tabsCleanedToday ?? 0,
           tabsCleanedDate: exportData.tabsCleanedDate ?? new Date().toISOString().split('T')[0],
+          tabActivityMap: exportData.tabActivityMap ?? {},
         });
       }
 


### PR DESCRIPTION
## Summary

The export-import feature was missing the `tabActivityMap` data stored in `chrome.storage.local`. This caused activity tracking data to be lost after importing settings.

## Changes

- **Export**: Added `tabActivityMap` to the `chrome.storage.local.get()` call and included it in the export JSON
- **Import**: Added `tabActivityMap` to the `chrome.storage.local.set()` call when restoring from a new-format backup
- **Backward compatibility**: Old export files without `tabActivityMap` default to an empty object `{}`

## Fixes

Closes #51